### PR TITLE
Adding State Management Options to CLI

### DIFF
--- a/.changeset/twenty-chefs-burn.md
+++ b/.changeset/twenty-chefs-burn.md
@@ -1,0 +1,9 @@
+---
+'create-expo-stack': minor
+---
+
+Added a StateManagement Question with zustand to start and potentially more to follow
+
+- setup with a question prompt just before the internationalization prompt
+- --zustand flag to skip the prompt
+- Adds a StateManagement folder to the project with a zustandStore.ts file to start with

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -296,6 +296,15 @@ const command: GluegunCommand = {
           });
         }
 
+        // State Management packages
+        if (options.zustand) {
+          // Add zustand package
+          cliResults.packages.push({
+            name: 'zustand',
+            type: 'state-management'
+          });
+        }
+
         // Internalization packages
         if (options.i18next) {
           cliResults.packages.push({
@@ -354,6 +363,12 @@ const command: GluegunCommand = {
                 script += '--drawer+tabs ';
               }
             }
+
+            const stateManagementPackage = cliResults.packages.find((p) => p.type === 'state-management');
+
+            if (stateManagementPackage) {
+              script += `--${stateManagementPackage.name} `;
+            }
           } else {
             // Add the packages
             cliResults.packages.forEach((p) => {
@@ -408,6 +423,9 @@ const command: GluegunCommand = {
         const internalizationPackage = packages.find((p) => p.type === 'internationalization');
         const analyticsPackage = packages.find((p) => p.type === 'analytics');
 
+        //add the state management package if it is selected
+        const stateManagementPackage = packages.find((p) => p.type === 'state-management') || undefined;
+
         let files: string[] = [];
 
         files = configureProjectFiles(
@@ -418,7 +436,8 @@ const command: GluegunCommand = {
           analyticsPackage,
           toolbox,
           cliResults,
-          internalizationPackage
+          internalizationPackage,
+          stateManagementPackage
         );
 
         // Once all the files are defined, format and generate them
@@ -434,7 +453,8 @@ const command: GluegunCommand = {
           packageManager,
           stylingPackage,
           toolbox,
-          internalizationPackage
+          internalizationPackage,
+          stateManagementPackage
         );
 
         await printOutput(cliResults, formattedFiles, toolbox, stylingPackage);

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -67,6 +67,10 @@
         "@react-native-community/slider": "4.5.2",
       <% } %>
     <% } %>
+
+    <% if (props.stateManagementPackage?.name === "zustand") { %>
+      "zustand": "^4.5.1",
+    <% } %>
     
     <% if (props.stylingPackage?.name === "restyle") { %>
       "@shopify/restyle": "^2.4.2",

--- a/cli/src/templates/packages/zustand/store/store.ts.ejs
+++ b/cli/src/templates/packages/zustand/store/store.ts.ejs
@@ -1,0 +1,15 @@
+import { create } from 'zustand'
+
+export interface BearState {
+  bears: number
+  increasePopulation: () => void
+  removeAllBears: () => void
+  updateBears: (newBears: number) => void
+}
+
+export const useStore = create<BearState>((set) => ({
+  bears: 0,
+  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
+  removeAllBears: () => set({ bears: 0 }),
+  updateBears: (newBears) => set({ bears: newBears }),
+}))

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -26,6 +26,7 @@ export const availablePackages = [
   'restyle',
   'unistyles',
   'i18next',
+  'zustand',
   'vexo-analytics'
 ] as const;
 
@@ -38,6 +39,8 @@ export type NavigationTypes = 'stack' | 'tabs' | 'drawer + tabs' | undefined;
 export type StylingSelect = 'nativewind' | 'restyle' | 'stylesheet' | 'tamagui' | 'unistyles' | 'nativewindui';
 
 export type PackageManager = 'yarn' | 'npm' | 'pnpm' | 'bun';
+
+export type StateManagementSelect = 'zustand' | undefined;
 
 export type Internalization = 'i18next';
 
@@ -59,7 +62,7 @@ export type SelectedComponents =
 
 export type AvailablePackages = {
   name: (typeof availablePackages)[number];
-  type: 'navigation' | 'styling' | 'authentication' | 'internationalization' | 'analytics';
+  type: 'navigation' | 'styling' | 'authentication' | 'internationalization' | 'state-management' | 'analytics';
   options?: { selectedComponents?: SelectedComponents[]; type?: NavigationTypes };
 };
 

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -21,7 +21,8 @@ export function configureProjectFiles(
   analyticsPackage: AvailablePackages | undefined,
   toolbox: Toolbox,
   cliResults: CliResults,
-  internalizationPackage: AvailablePackages | undefined
+  internalizationPackage: AvailablePackages | undefined,
+  stateManagementPackage: AvailablePackages | undefined
 ): string[] {
   // Define the files common to all templates to be generated
   let baseFiles = [
@@ -347,6 +348,12 @@ export function configureProjectFiles(
 
       files = [...files, ...i18nextFiles];
     }
+  }
+
+  // add state management files if needed
+  if (stateManagementPackage?.name === 'zustand') {
+    const zustandFiles = ['packages/zustand/store/store.ts.ejs'];
+    files = [...files, ...zustandFiles];
   }
 
   // Add npmrc file if user is using pnpm

--- a/cli/src/utilities/generateProjectFiles.ts
+++ b/cli/src/utilities/generateProjectFiles.ts
@@ -11,7 +11,8 @@ export function generateProjectFiles(
   packageManager: PackageManager,
   stylingPackage: AvailablePackages | undefined,
   toolbox: Toolbox,
-  internalizationPackage: AvailablePackages | undefined
+  internalizationPackage: AvailablePackages | undefined,
+  stateManagementPackage: AvailablePackages | undefined
 ) {
   const { projectName, packages, flags } = cliResults;
 
@@ -25,6 +26,11 @@ export function generateProjectFiles(
 
     if (authenticationPackage?.name === 'firebase') {
       target = target.replace('packages/firebase/', '');
+    }
+
+    //state management
+    if (stateManagementPackage?.name === 'zustand') {
+      target = target.replace('packages/zustand/', '');
     }
 
     target = target.replace('base/', '');
@@ -79,7 +85,8 @@ export function generateProjectFiles(
         packageManager,
         packages,
         stylingPackage,
-        internalizationPackage
+        internalizationPackage,
+        stateManagementPackage
       }
     });
 

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -5,6 +5,7 @@ import { semver } from 'gluegun';
 import { bunInstallationError, defaultOptions, nativeWindUIOptions } from '../constants';
 import {
   AuthenticationSelect,
+  StateManagementSelect,
   CliResults,
   NavigationSelect,
   NavigationTypes,
@@ -325,6 +326,32 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
         stylingSelect.toString().charAt(0).toUpperCase() + stylingSelect.toString().slice(1)
       }!`
     );
+  }
+
+  const stateManagementSelect = await select({
+    message: 'What would you like to use for state management?',
+    options: [
+      { value: undefined, label: 'None' },
+      { value: 'zustand', label: 'Zustand' }
+      // { value: 'mobx', label: 'MobX' },
+      // { value: 'redux', label: 'Redux' },
+    ]
+  });
+
+  if (isCancel(stateManagementSelect)) {
+    cancel('Cancelled... 👋');
+    return process.exit(0);
+  }
+
+  if (stateManagementSelect) {
+    cliResults.packages.push({
+      name: stateManagementSelect as StateManagementSelect,
+      type: 'state-management'
+    });
+
+    success(`You'll be using ${stateManagementSelect} for state management.`);
+  } else {
+    success(`No problem, skipping state management for now.`);
   }
 
   const authenticationSelect = await select({

--- a/docs/src/content/docs/en/installation.md
+++ b/docs/src/content/docs/en/installation.md
@@ -73,5 +73,6 @@ bun create expo-stack myapp --expo-router --nativewind --bun
 | `--tamagui`          | Use Tamagui for styling                                                        |
 | `--restyle`          | Use Restyle for styling                                                        |
 | `--stylesheet`       | Use StyleSheet for styling, used by default                                    |
+| `--zustand`          | Use Zustand for state management                                               |
 | `--i18next`          | Use i18next for internationalization                                           |
 | `-i`, `--ignite`     | Initialize an opinionated starter using Infinite Red's Ignite                  |


### PR DESCRIPTION
## Description

I had added state management options to the ces flow
- Initially I have only added Zustand but with the approval of this PR I will look into adding other optons too
- Adds a question on the flow (see image) 
- Adds a --zustand flag to skip the question too.
This creates a folder in the root directory called state management with a default store from the zustand docs, it could be updated in future with a more generic store and some comments on how to use but to start with its the default store from zustand docs

## Motivation and Context

My motivation was as I believe that ces can and should become one of the best and number one go to option for starting new RN expo apps and state management is mandatory in almost every app asit scales and having the setup from the get go is a must, as well as this the intuitive nature of ces means that for beginner RN devs they can use it and this will ease them into state management, in short ces should have eveything you could need, state management is one such item

## Screenshots (if appropriate):

![image](https://github.com/danstepanov/create-expo-stack/assets/65453441/160a6501-65ce-4a42-a325-9f4cde4704ec)
