### PR TITLE
fix: notfound in wrong place #342

### DIFF
--- a/.changeset/rich-bugs-tickle.md
+++ b/.changeset/rich-bugs-tickle.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: path for not found with tabs setup

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -323,7 +323,7 @@ export function configureProjectFiles(
           'packages/expo-router/tabs/app/(tabs)/two.tsx.ejs',
           'packages/expo-router/tabs/app/_layout.tsx.ejs',
           'packages/expo-router/tabs/app/modal.tsx.ejs',
-          'packages/expo-router/stack/app/+not-found.tsx.ejs',
+          'packages/expo-router/tabs/app/+not-found.tsx.ejs',
           'packages/expo-router/tabs/app/+html.tsx.ejs'
         ];
         // add the necessary components for the navigation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

path was wrong for the not-found file

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue
closes #342
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

fix the issue in #342

## How Has This Been Tested?

ran it locally 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

![image](https://github.com/roninoss/create-expo-stack/assets/3481514/177aff82-d907-4ae9-9d26-02bd869cff4c)

