### PR TITLE
fix: rerun script doesnt need expo router for NWUI

### DIFF
--- a/.changeset/grumpy-adults-trade.md
+++ b/.changeset/grumpy-adults-trade.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: rerun script more accurate for NWUI

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -313,7 +313,7 @@ const command: GluegunCommand = {
 
         // Function that outputs a string given the CLI results and the packageManager. The outputted string should be a command that can be run to recreate the project
         const generateRerunScript = (cliResults: CliResults) => {
-          let script = `npx create-expo-stack ${cliResults.projectName} `;
+          let script = `npx create-expo-stack@latest ${cliResults.projectName} `;
 
           const isNativeWindUISelected = cliResults.packages.some((p) => p.name === 'nativewindui');
 

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -329,6 +329,7 @@ const command: GluegunCommand = {
               script += `--selected-components=${nativeWindUIComponents.join(',')} `;
             }
 
+            // this should always be expo router for nwui
             const chosenNavigationOption = cliResults.packages.find((p) => p.type === 'navigation');
 
             const hasNavigationPackage = chosenNavigationOption !== undefined;
@@ -336,9 +337,8 @@ const command: GluegunCommand = {
             const navigationType = chosenNavigationOption.options.type;
 
             if (hasNavigationPackage) {
-              script += `--${chosenNavigationOption.name} `;
-
-              // add --tabs or --drawer+tabs if navigation package is selected
+              // NOTE we don't need to add expo-router since its currently getting automatically added with nativewindui
+              // NOTE stack is default so doesn't need to applied.
               if (navigationType === 'tabs') {
                 script += '--tabs ';
               } else if (navigationType === 'drawer + tabs') {


### PR DESCRIPTION
- **fix: rerun script doesnt need expo router for NWUI**

<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Since expo router is added by default we can remove it from the rerun script

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
