### PR TITLE
fix: include `@latest` tag when copying the command

### DIFF
--- a/www/src/components/landing/hero/copyCommandButton.tsx
+++ b/www/src/components/landing/hero/copyCommandButton.tsx
@@ -5,7 +5,7 @@ const CopyCommandButton = () => {
 
   function toggleIcon() {
     setDelayedCopyText();
-    copy("npx create-expo-stack");
+    copy("npx create-expo-stack@latest");
   }
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

The command copied to the clipboard does not include the `@latest` tag (while the code shown does)

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

This was missed on https://github.com/roninoss/create-expo-stack/commit/8b560e3d45502c6dbdbc4273ffaa82e198f71de0
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
