### PR TITLE
fix: should always prompt about deleting unless using --overwrite

### DIFF
--- a/.changeset/smooth-gifts-lay.md
+++ b/.changeset/smooth-gifts-lay.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: should always prompt about deleting unless using --overwrite

--- a/cli/__tests__/cli-integration.test.ts
+++ b/cli/__tests__/cli-integration.test.ts
@@ -160,7 +160,7 @@ for (const packageManager of packageManagers) {
 test(`generates a default project with i18n`, async () => {
   const output = await generateProject({
     projectName: 'myTestProject',
-    flags: ['--default', `--i18next`, `--bun`]
+    flags: ['--default', `--i18next`, `--bun`, '--overwrite']
   });
 
   expect(output).toContain('--i18next');

--- a/cli/src/utilities/validateProjectName.ts
+++ b/cli/src/utilities/validateProjectName.ts
@@ -10,32 +10,32 @@ export async function validateProjectName(
   overwrite: boolean
 ): Promise<void> {
   const s = spinner();
+
   if (!exists(projectName)) {
     return;
   }
 
-  if (overwrite || (exists(projectName) === 'dir' && !prompt)) {
+  if (overwrite) {
     await removeAsync(projectName);
+
     return;
   }
 
-  if (prompt != null) {
-    const shouldDeleteExistingProject = await confirm({
-      message: `A folder with the name '${projectName}' already exists. Do you want to delete it?`,
-      initialValue: true
-    });
+  const shouldDeleteExistingProject = await confirm({
+    message: `A folder with the name '${projectName}' already exists. Do you want to delete it?`,
+    initialValue: true
+  });
 
-    if (isCancel(shouldDeleteExistingProject)) {
-      cancel('Cancelled... 👋');
-      return process.exit(0);
-    }
+  if (isCancel(shouldDeleteExistingProject)) {
+    cancel('Cancelled... 👋');
+    return process.exit(0);
+  }
 
-    if (shouldDeleteExistingProject) {
-      s.start('Deleting existing project. This may take a minute...');
-      await removeAsync(projectName);
-      s.stop(`Deleted existing directory: ${projectName}`);
-      return;
-    }
+  if (shouldDeleteExistingProject) {
+    s.start('Deleting existing project. This may take a minute...');
+    await removeAsync(projectName);
+    s.stop(`Deleted existing directory: ${projectName}`);
+    return;
   }
 
   throw new Error(`A project with the name '${projectName}' already exists.`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Just removes some unnecessary checks around the deletion that was stopping the user from being prompted when running in non-interactive mode. User can pass overwrite to skip the prompt.

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

closes #385 

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

#385

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/bdde2deb-f2ee-47a2-b2a7-ae3bffc56d0a)
