### PR TITLE
fix: make sure npmrc gets added for pnpm

### DIFF
--- a/.changeset/proud-humans-hug.md
+++ b/.changeset/proud-humans-hug.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: make sure npmrc gets added for pnpm

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -43,10 +43,6 @@ export function configureProjectFiles(
   }
 
   const packageManager = getPackageManager(toolbox, cliResults);
-  // Add npmrc file if user is using pnpm and expo router
-  if (packageManager === 'pnpm') {
-    baseFiles.push('base/.npmrc.ejs');
-  }
 
   if (stylingPackage?.name === 'nativewindui') {
     let nativewindUIFiles = [
@@ -351,6 +347,11 @@ export function configureProjectFiles(
 
       files = [...files, ...i18nextFiles];
     }
+  }
+
+  // Add npmrc file if user is using pnpm
+  if (packageManager === 'pnpm') {
+    files.push('base/.npmrc.ejs');
   }
 
   const packageManagerVersion = getVersionForPackageManager(cliResults.flags.packageManager);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Nativewindui creates its own list of files separate from the base so npmrc wasn't getting added

I just moved it to the end so that its always applied when pnpm is used

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
