### PR TITLE
add redux

### DIFF
--- a/.changeset/thin-wolves-push.md
+++ b/.changeset/thin-wolves-push.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': minor
+---
+
+add redux

--- a/cli/src/commands/create-expo-stack.ts
+++ b/cli/src/commands/create-expo-stack.ts
@@ -309,6 +309,14 @@ const command: GluegunCommand = {
           cliResults.packages.push({ name: 'vexo-analytics', type: 'analytics' });
         }
 
+        if (options.redux) {
+          // Add redux package
+          cliResults.packages.push({
+            name: 'redux',
+            type: 'state-management'
+          });
+        }
+
         // By this point, all cliResults should be set
         info('');
         highlight('Your project configuration:');
@@ -407,6 +415,7 @@ const command: GluegunCommand = {
         const stylingPackage = packages.find((p) => p.type === 'styling');
         const internalizationPackage = packages.find((p) => p.type === 'internationalization');
         const analyticsPackage = packages.find((p) => p.type === 'analytics');
+        const stateManagementPackage = packages.find((p) => p.type === 'state-management') || undefined;
 
         let files: string[] = [];
 
@@ -418,7 +427,8 @@ const command: GluegunCommand = {
           analyticsPackage,
           toolbox,
           cliResults,
-          internalizationPackage
+          internalizationPackage,
+          stateManagementPackage
         );
 
         // Once all the files are defined, format and generate them
@@ -434,7 +444,8 @@ const command: GluegunCommand = {
           packageManager,
           stylingPackage,
           toolbox,
-          internalizationPackage
+          internalizationPackage,
+          stateManagementPackage
         );
 
         await printOutput(cliResults, formattedFiles, toolbox, stylingPackage);

--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -2,72 +2,95 @@ import { ScreenContent } from 'components/ScreenContent';
 import { StatusBar } from 'expo-status-bar';
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  import './translation';
-  import { InternalizationExample } from 'components/InternalizationExample';
+import './translation';
+import { InternalizationExample } from 'components/InternalizationExample';
 <% } %>
 
 <% if (props.stylingPackage?.name === "nativewind") { %>
-  import './global.css';
+import './global.css';
 <% } else if (props.stylingPackage?.name === "nativewinui") { %>
-  import './global.css';
-  import 'expo-dev-client';
+import './global.css';
+import 'expo-dev-client';
 <% } else if (props.stylingPackage?.name === "restyle") { %>
-  import { ThemeProvider } from '@shopify/restyle';
-  import { theme } from 'theme';
+import { ThemeProvider } from '@shopify/restyle';
+import { theme } from 'theme';
 <% } else if (props.stylingPackage?.name === "tamagui") { %>
-  <% if (!props.internalizationPackage) { %>
-    import { Text } from 'react-native';
-  <% } %>
-  import { TamaguiProvider } from 'tamagui';
-  import config from './tamagui.config';
+<% if (!props.internalizationPackage) { %>
+import { Text } from 'react-native';
+<% } %>
+import { TamaguiProvider } from 'tamagui';
+import config from './tamagui.config';
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
+import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
 <% } %>
+
+<% if (props.stateManagementPackage?.name === "redux") { %>
+import { Provider } from 'react-redux'
+import store from 'store/store'
+<% } %>
+
 
 <% if (props.stylingPackage?.name === "restyle") {%>
-  export default function App() {   
-    return (
-      <ThemeProvider theme={theme}>
-        <ScreenContent title="Home" path="App.tsx">
-        <% if (props.internalizationPackage?.name === "i18next") { %>
-          <InternalizationExample />
-        <% } %>
-        </ScreenContent>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    );
-  }
+export default function App() {
+return (
+<ThemeProvider theme={theme}>
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+  <Provider store={store}>
+    <% } %>
+    <ScreenContent title="Home" path="App.tsx">
+      <% if (props.internalizationPackage?.name === "i18next") { %>
+      <InternalizationExample />
+      <% } %>
+    </ScreenContent>
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+  </Provider>
+  <% } %>
+  <StatusBar style="auto" />
+</ThemeProvider>
+);
+}
 <% } else if (props.stylingPackage?.name === "tamagui") {%>
-  export default function App() {
-    return (
-      <TamaguiProvider config={config}>
-        <ScreenContent title="Home" path="App.tsx">
-        <% if (props.internalizationPackage?.name === "i18next") { %>
-          <InternalizationExample />
-        <% } else { %>
-          <Text>Open up App.tsx to start working on your app!</Text>
-        <% } %>
-        </ScreenContent>
-        <StatusBar style="auto" />
-      </TamaguiProvider>
-    );
-  }
+export default function App() {
+return (
+<TamaguiProvider config={config}>
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+  <Provider store={store}>
+    <% } %>
+    <ScreenContent title="Home" path="App.tsx">
+      <% if (props.internalizationPackage?.name === "i18next") { %>
+      <InternalizationExample />
+      <% } else { %>
+      <Text>Open up App.tsx to start working on your app!</Text>
+      <% } %>
+    </ScreenContent>
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+  </Provider>
+  <% } %>
+  <StatusBar style="auto" />
+</TamaguiProvider>
+);
+}
 <% } else { %>
-  export default function App() {
-    return (
-      <>
-        <ScreenContent title="Home" path="App.tsx">
-        <% if (props.internalizationPackage?.name === "i18next") { %>
-          <InternalizationExample />
-        <% } %>
-        </ScreenContent>
-        <StatusBar style="auto" />
-      </>
-    );
-  }
+export default function App() {
+return (
+<>
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+  <Provider store={store}>
+    <% } %>
+    <ScreenContent title="Home" path="App.tsx">
+      <% if (props.internalizationPackage?.name === "i18next") { %>
+      <InternalizationExample />
+      <% } %>
+    </ScreenContent>
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+  </Provider>
+  <% } %>
+  <StatusBar style="auto" />
+</>
+);
+}
 <% } %>
-

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -93,6 +93,11 @@
       "vexo-analytics": "^1.3.15",
     <% } %>
 
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+      "react-redux": "^9.1.2",
+      "@reduxjs/toolkit": "^2.2.7",
+    <% } %>
+
     <% if ((props.navigationPackage?.name === "react-navigation") && (props.stylingPackage?.name === "tamagui")) { %>
       "expo-splash-screen": "~0.27.4",
     <% } %>

--- a/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
@@ -1,15 +1,15 @@
 <% if (props.stylingPackage?.name === "nativewind") { %>
-  import '../global.css';
+import '../global.css';
 <% } else if (props.stylingPackage?.name === "nativewinui") { %>
-  import '../global.css';
-  import 'expo-dev-client';
+import '../global.css';
+import 'expo-dev-client';
 <% } %>
 <% if (props.stylingPackage?.name === "unistyles") { %>
 import '../unistyles';
 <% } %>
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  import '../translation';
+import '../translation';
 <% } %>
 
 import 'react-native-gesture-handler';
@@ -17,63 +17,74 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Stack } from 'expo-router';
 
 <% if (props.stylingPackage?.name==="tamagui" ) { %>
-  import React, { useEffect } from "react";
-  import { TamaguiProvider } from 'tamagui'
-  import { SplashScreen } from "expo-router";
-  import { useFonts } from "expo-font";
+import React, { useEffect } from "react";
+import { TamaguiProvider } from 'tamagui'
+import { SplashScreen } from "expo-router";
+import { useFonts } from "expo-font";
 
-  import config from '../tamagui.config';
+import config from '../tamagui.config';
 
-	SplashScreen.preventAutoHideAsync();
+SplashScreen.preventAutoHideAsync();
 <% }  else if (props.stylingPackage?.name === "restyle") { %>
-  import { ThemeProvider } from '@shopify/restyle';
-  
-  import { theme } from '../theme';
+import { ThemeProvider } from '@shopify/restyle';
+
+import { theme } from '../theme';
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
+import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+<% } %>
+<% if (props.stateManagementPackage?.name === "redux") { %>
+import { Provider } from 'react-redux'
+import store from 'store/store'
 <% } %>
 
+
 export const unstable_settings = {
-  // Ensure that reloading on `/modal` keeps a back button present.
-  initialRouteName: "(drawer)",
+// Ensure that reloading on `/modal` keeps a back button present.
+initialRouteName: "(drawer)",
 };
 
 export default function RootLayout() {
-  <% if (props.stylingPackage?.name==="tamagui" ) { %>
-    const [loaded] = useFonts({
-      Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
-      InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
-    });
+<% if (props.stylingPackage?.name==="tamagui" ) { %>
+const [loaded] = useFonts({
+Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
+InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
+});
 
-    useEffect(() => {
-      if (loaded) {
-        SplashScreen.hideAsync();
-      }
-    }, [loaded]);
+useEffect(() => {
+if (loaded) {
+SplashScreen.hideAsync();
+}
+}, [loaded]);
 
-    if (!loaded) return null;
-  <% } %>
+if (!loaded) return null;
+<% } %>
 
-  	return (
-    	<% if (props.stylingPackage?.name === "tamagui") { %>
-    		<TamaguiProvider config={config}>
-    	<% } else if (props.stylingPackage?.name === "restyle") { %>
-    		<ThemeProvider theme={theme}>
-    	<% } %>
-        <GestureHandlerRootView style={{ flex: 1 }}>
-          <Stack>
-            <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
-            <Stack.Screen name="modal" options={{ title: 'Modal', presentation: 'modal' }} />
-          </Stack>
-        </GestureHandlerRootView>
-      <% if (props.stylingPackage?.name === "tamagui") { %>
-        </TamaguiProvider>
-      <% } else if (props.stylingPackage?.name === "restyle") { %>
-        </ThemeProvider>
+return (
+<% if (props.stylingPackage?.name === "tamagui") { %>
+<TamaguiProvider config={config}>
+  <% } else if (props.stylingPackage?.name === "restyle") { %>
+  <ThemeProvider theme={theme}>
+    <% } %>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <% if (props.stateManagementPackage?.name === "redux") { %>
+      <Provider store={store}>
+        <% } %>
+        <Stack>
+          <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
+          <Stack.Screen name="modal" options={{ title: 'Modal', presentation: 'modal' }} />
+        </Stack>
+        <% if (props.stateManagementPackage?.name === "redux") { %>
+      </Provider>
       <% } %>
-  );
+    </GestureHandlerRootView>
+    <% if (props.stylingPackage?.name === "tamagui") { %>
+</TamaguiProvider>
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+</ThemeProvider>
+<% } %>
+);
 }

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -1,61 +1,72 @@
 <% if (props.stylingPackage?.name === "nativewind") { %>
-  import '../global.css';
+import '../global.css';
 <% } %>
 
 <% if (props.stylingPackage?.name === "unistyles") { %>
 import '../unistyles';
 <% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  import '../translation';
+import '../translation';
 <% } %>
 
 <% if (props.stylingPackage?.name === "tamagui") { %>
-	import { useFonts } from 'expo-font';
-  import { SplashScreen, Stack } from 'expo-router';
-  import { useEffect } from 'react';
-  import { TamaguiProvider } from 'tamagui';
+import { useFonts } from 'expo-font';
+import { SplashScreen, Stack } from 'expo-router';
+import { useEffect } from 'react';
+import { TamaguiProvider } from 'tamagui';
 
-  import config from '../tamagui.config';
+import config from '../tamagui.config';
 <% } else if (props.stylingPackage?.name === "restyle") { %>
-  import { ThemeProvider } from '@shopify/restyle';
-  import { theme } from 'theme';
+import { ThemeProvider } from '@shopify/restyle';
+import { theme } from 'theme';
 <% } %>
-	import { Stack } from "expo-router";
+import { Stack } from "expo-router";
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
+import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
 <% } %>
+<% if (props.stateManagementPackage?.name === "redux") { %>
+import { Provider } from 'react-redux'
+import store from 'store/store'
+<% } %>
+
 
 export default function Layout() {
 
-  <% if (props.stylingPackage?.name === "tamagui") { %>
-  	const [loaded] = useFonts({
-			Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
-			InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
-		});
+<% if (props.stylingPackage?.name === "tamagui") { %>
+const [loaded] = useFonts({
+Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
+InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
+});
 
-		useEffect(() => {
-			if (loaded) {
-				SplashScreen.hideAsync();
-			}
-		}, [loaded]);
+useEffect(() => {
+if (loaded) {
+SplashScreen.hideAsync();
+}
+}, [loaded]);
 
-		if (!loaded) return null;
-  <% } %>
+if (!loaded) return null;
+<% } %>
 
-	return (
-		<% if (props.stylingPackage?.name === "tamagui") { %>
-			<TamaguiProvider config={config}>
-		<% } else if (props.stylingPackage?.name === "restyle") { %>
-			<ThemeProvider theme={theme}>
-		<% } %>
-		    <Stack />
-		<% if (props.stylingPackage?.name === "tamagui") { %>
-			</TamaguiProvider>
-		<% } else if (props.stylingPackage?.name === "restyle") { %>
-			</ThemeProvider >
-		<% } %>
-	);
+return (
+<% if (props.stylingPackage?.name === "tamagui") { %>
+<TamaguiProvider config={config}>
+  <% } else if (props.stylingPackage?.name === "restyle") { %>
+  <ThemeProvider theme={theme}>
+    <% } %>
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+    <Provider store={store}>
+      <% } %>
+      <Stack />
+      <% if (props.stateManagementPackage?.name === "redux") { %>
+    </Provider>
+    <% } %>
+    <% if (props.stylingPackage?.name === "tamagui") { %>
+</TamaguiProvider>
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+</ThemeProvider>
+<% } %>
+);
 }

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -1,74 +1,86 @@
 <% if (props.stylingPackage?.name === "nativewind") { %>
-  import '../global.css';
+import '../global.css';
 <% } else if (props.stylingPackage?.name === "nativewinui") { %>
-  import '../global.css';
-  import 'expo-dev-client';
+import '../global.css';
+import 'expo-dev-client';
 <% } %>
 <% if (props.stylingPackage?.name === "unistyles") { %>
 import '../unistyles';
 <% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  import '../translation';
+import '../translation';
 <% } %>
 
 <% if (props.stylingPackage?.name === "tamagui") { %>
-	import React, { useEffect } from "react";
-	import { TamaguiProvider } from 'tamagui'
-	import { SplashScreen, Stack } from "expo-router";
-	import { useFonts } from "expo-font";
+import React, { useEffect } from "react";
+import { TamaguiProvider } from 'tamagui'
+import { SplashScreen, Stack } from "expo-router";
+import { useFonts } from "expo-font";
 
-	import config from '../tamagui.config'
+import config from '../tamagui.config'
 
-	SplashScreen.preventAutoHideAsync();
+SplashScreen.preventAutoHideAsync();
 <% } else if (props.stylingPackage?.name === "restyle") { %>
-  import { ThemeProvider } from '@shopify/restyle';
-  import { Stack } from 'expo-router';
-  import { theme } from 'theme';
+import { ThemeProvider } from '@shopify/restyle';
+import { Stack } from 'expo-router';
+import { theme } from 'theme';
 <% } else { %>
-	import { Stack } from "expo-router";
+import { Stack } from "expo-router";
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
+import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
+vexo(process.env.EXPO_PUBLIC_VEXO_API_KEY);
 <% } %>
 
+<% if (props.stateManagementPackage?.name === "redux") { %>
+import { Provider } from 'react-redux'
+import store from 'store/store'
+<% } %>
+
+
 export const unstable_settings = {
-	// Ensure that reloading on `/modal` keeps a back button present.
-	initialRouteName: "(tabs)",
+// Ensure that reloading on `/modal` keeps a back button present.
+initialRouteName: "(tabs)",
 };
 
 export default function RootLayout() {
-  	<% if (props.stylingPackage?.name === "tamagui") { %>
-    	const [loaded] = useFonts({
-      		Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
-      		InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
-    	});
+<% if (props.stylingPackage?.name === "tamagui") { %>
+const [loaded] = useFonts({
+Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
+InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf")
+});
 
-    	useEffect(() => {
-      		if (loaded) {
-        		SplashScreen.hideAsync();
-      		}
-    	}, [loaded]);
+useEffect(() => {
+if (loaded) {
+SplashScreen.hideAsync();
+}
+}, [loaded]);
 
-    	if (!loaded) return null;
-  	<% } %>
+if (!loaded) return null;
+<% } %>
 
-  	return (
-    	<% if (props.stylingPackage?.name === "tamagui") { %>
-    		<TamaguiProvider config={config}>
-    	<% } else if (props.stylingPackage?.name === "restyle") { %>
-    		<ThemeProvider theme={theme}>
-    	<% } %>
-		<Stack>
-			<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-			<Stack.Screen name="modal" options={{ presentation: "modal" }} />
-		</Stack>
-		<% if (props.stylingPackage?.name === "tamagui") { %>
-			</TamaguiProvider>
-		<% } else if (props.stylingPackage?.name === "restyle") { %>
-			</ThemeProvider>
-		<% } %>
-  	);
+return (
+<% if (props.stylingPackage?.name === "tamagui") { %>
+<TamaguiProvider config={config}>
+  <% } else if (props.stylingPackage?.name === "restyle") { %>
+  <ThemeProvider theme={theme}>
+    <% } %>
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+    <Provider store={store}>
+      <% } %>
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="modal" options={{ presentation: "modal" }} />
+      </Stack>
+      <% if (props.stateManagementPackage?.name === "redux") { %>
+    </Provider>
+    <% } %>
+    <% if (props.stylingPackage?.name === "tamagui") { %>
+</TamaguiProvider>
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+</ThemeProvider>
+<% } %>
+);
 }

--- a/cli/src/templates/packages/react-navigation/App.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/App.tsx.ejs
@@ -1,69 +1,95 @@
 <% if (props.stylingPackage?.name === "nativewind") { %>
-  import './global.css';
+import './global.css';
 <% } else if (props.stylingPackage?.name === "nativewinui") { %>
-  import './global.css';
-  import 'expo-dev-client';
+import './global.css';
+import 'expo-dev-client';
 <% } %>
 <% if (props.stylingPackage?.name === "unistyles") { %>
 import './unistyles';
 <% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  import './translation';
+import './translation';
 <% } %>
 import "react-native-gesture-handler";
 <% if (props.stylingPackage?.name === "tamagui") { %>
-	import React, { useEffect } from "react";
-	import { TamaguiProvider } from 'tamagui';
-	import * as SplashScreen from 'expo-splash-screen';
-	import { useFonts } from 'expo-font';
+import React, { useEffect } from "react";
+import { TamaguiProvider } from 'tamagui';
+import * as SplashScreen from 'expo-splash-screen';
+import { useFonts } from 'expo-font';
 
-	import config from './tamagui.config'
+import config from './tamagui.config'
 
-	SplashScreen.preventAutoHideAsync();
+SplashScreen.preventAutoHideAsync();
 <% } else if (props.stylingPackage?.name === "restyle") { %>
-  import { ThemeProvider } from '@shopify/restyle';
-  import { theme } from 'theme';
+import { ThemeProvider } from '@shopify/restyle';
+import { theme } from 'theme';
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
-  import { vexo } from 'vexo-analytics';
+import { vexo } from 'vexo-analytics';
 
-  vexo(process.env.VEXO_API_KEY); // eslint-disable-line
+vexo(process.env.VEXO_API_KEY); // eslint-disable-line
 
-  import RootStack from "./navigation"; // eslint-disable-line
+import RootStack from "./navigation"; // eslint-disable-line
 <% } else { %>
-  import RootStack from "./navigation";
+import RootStack from "./navigation";
+<% } %>
+<% if (props.stateManagementPackage?.name === "redux") { %>
+import { Provider } from 'react-redux'
+import store from 'store/store'
 <% } %>
 
 export default function App() {
-	<% if (props.stylingPackage?.name === "tamagui") { %>
-		const [loaded] = useFonts({
-			Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
-			InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf"),
-		});
+<% if (props.stylingPackage?.name === "tamagui") { %>
+const [loaded] = useFonts({
+Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
+InterBold: require("@tamagui/font-inter/otf/Inter-Bold.otf"),
+});
 
-		useEffect(() => {
-			if (loaded) {
-				SplashScreen.hideAsync();
-			}
-		}, [loaded])
+useEffect(() => {
+if (loaded) {
+SplashScreen.hideAsync();
+}
+}, [loaded])
 
-		if (!loaded) {
-			return null;
-		}
+if (!loaded) {
+return null;
+}
 
-		return (
-			<TamaguiProvider config={config}>
-				<RootStack />
-			</TamaguiProvider>
-		);
-	<% } else if (props.stylingPackage?.name === "restyle") { %>
-		return (
-      <ThemeProvider theme={theme}>
-        <RootStack />
-      </ThemeProvider>
-    );
-	<% } else { %> 
-		return <RootStack />;
-	<% } %>
+return (
+<TamaguiProvider config={config}>
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+  <Provider store={store}>
+    <% } %>
+    <RootStack />
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+  </Provider>
+  <% } %>
+</TamaguiProvider>
+);
+<% } else if (props.stylingPackage?.name === "restyle") { %>
+return (
+<ThemeProvider theme={theme}>
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+  <Provider store={store}>
+    <% } %>
+    <RootStack />
+    <% if (props.stateManagementPackage?.name === "redux") { %>
+  </Provider>
+
+  <% } %>
+</ThemeProvider>
+);
+<% } else { %>
+return(
+<% if (props.stateManagementPackage?.name === "redux") { %>
+<Provider store={store}>
+  <% } %>
+  <RootStack />
+  <% if (props.stateManagementPackage?.name === "redux") { %>
+</Provider>
+
+<% } %>
+)
+<% } %>
 }

--- a/cli/src/templates/packages/redux/store/reducers/demoSlice.ts.ejs
+++ b/cli/src/templates/packages/redux/store/reducers/demoSlice.ts.ejs
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface InitialState {
+demo: undefined;
+}
+
+const initialState: InitialState = {
+demo: undefined,
+};
+
+export const demoSlice = createSlice({
+name: 'demo',
+initialState,
+reducers: {
+setDemo: (state, action) => {
+state.demo = action.payload;
+},
+},
+});
+
+export const { setDemo } = demoSlice.actions;
+
+export default demoSlice.reducer;

--- a/cli/src/templates/packages/redux/store/store.ts.ejs
+++ b/cli/src/templates/packages/redux/store/store.ts.ejs
@@ -1,0 +1,23 @@
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useDispatch, useSelector } from 'react-redux'
+
+import demoReducer from './reducers/demoSlice'
+
+
+const rootReducer = combineReducers({
+demo: demoReducer,
+})
+
+
+const store = configureStore({
+reducer: rootReducer,
+})
+
+export default store
+
+export type RootState = ReturnType<typeof store.getState>
+
+  type AppDispatch = typeof store.dispatch
+
+  export const useAppDispatch = useDispatch.withTypes<AppDispatch>()
+    export const useAppSelector = useSelector.withTypes<RootState>()

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -26,7 +26,8 @@ export const availablePackages = [
   'restyle',
   'unistyles',
   'i18next',
-  'vexo-analytics'
+  'vexo-analytics',
+  'redux'
 ] as const;
 
 export type AuthenticationSelect = 'supabase' | 'firebase' | undefined;
@@ -42,6 +43,8 @@ export type PackageManager = 'yarn' | 'npm' | 'pnpm' | 'bun';
 export type Internalization = 'i18next';
 
 export type Analytics = 'vexo-analytics';
+
+export type StateManagement = 'redux' | undefined;
 
 export type SelectedComponents =
   | 'action-sheet'
@@ -59,7 +62,7 @@ export type SelectedComponents =
 
 export type AvailablePackages = {
   name: (typeof availablePackages)[number];
-  type: 'navigation' | 'styling' | 'authentication' | 'internationalization' | 'analytics';
+  type: 'navigation' | 'styling' | 'authentication' | 'internationalization' | 'analytics' | 'state-management';
   options?: { selectedComponents?: SelectedComponents[]; type?: NavigationTypes };
 };
 

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -21,7 +21,8 @@ export function configureProjectFiles(
   analyticsPackage: AvailablePackages | undefined,
   toolbox: Toolbox,
   cliResults: CliResults,
-  internalizationPackage: AvailablePackages | undefined
+  internalizationPackage: AvailablePackages | undefined,
+  stateManagementPackage: AvailablePackages | undefined
 ): string[] {
   // Define the files common to all templates to be generated
   let baseFiles = [
@@ -346,6 +347,13 @@ export function configureProjectFiles(
       ];
 
       files = [...files, ...i18nextFiles];
+    }
+
+    // add redux files if needed
+    if (stateManagementPackage?.name === 'redux') {
+      const reduxFiles = ['packages/redux/store/store.ts.ejs', 'packages/redux/store/reducers/demoSlice.ts.ejs'];
+
+      files = [...files, ...reduxFiles];
     }
   }
 

--- a/cli/src/utilities/generateProjectFiles.ts
+++ b/cli/src/utilities/generateProjectFiles.ts
@@ -11,7 +11,8 @@ export function generateProjectFiles(
   packageManager: PackageManager,
   stylingPackage: AvailablePackages | undefined,
   toolbox: Toolbox,
-  internalizationPackage: AvailablePackages | undefined
+  internalizationPackage: AvailablePackages | undefined,
+  stateManagementPackage: AvailablePackages | undefined
 ) {
   const { projectName, packages, flags } = cliResults;
 
@@ -67,6 +68,10 @@ export function generateProjectFiles(
       target = target.replace('packages/vexo-analytics/', '');
     }
 
+    if (stateManagementPackage?.name === 'redux') {
+      target = target.replace('packages/redux/', '');
+    }
+
     const gen = toolbox.template.generate({
       template,
       target: `./${projectName}/` + target,
@@ -79,7 +84,8 @@ export function generateProjectFiles(
         packageManager,
         packages,
         stylingPackage,
-        internalizationPackage
+        internalizationPackage,
+        stateManagementPackage
       }
     });
 

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -10,7 +10,8 @@ import {
   NavigationTypes,
   PackageManager,
   SelectedComponents,
-  StylingSelect
+  StylingSelect,
+  StateManagement
 } from '../types';
 import { loadConfigs, saveConfig } from './configStorage';
 import { getDefaultPackageManagerVersion } from './getPackageManager';
@@ -344,6 +345,24 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
     cliResults.packages.push({ name: authenticationSelect as AuthenticationSelect, type: 'authentication' });
   } else {
     success(`No problem, skipping authentication for now.`);
+  }
+
+  const stateManagementSelect = await select({
+    message: 'What would you like to use for state management?',
+    options: [
+      { value: undefined, label: 'None' },
+      { value: 'redux', label: 'Redux' }
+    ]
+  });
+
+  if (isCancel(stateManagementSelect)) {
+    cancel('Cancelled... 👋');
+    return process.exit(0);
+  }
+  if (stateManagementSelect) {
+    cliResults.packages.push({ name: stateManagementSelect as StateManagement, type: 'state-management' });
+  } else {
+    success(`No problem, skipping state management for now.`);
   }
 
   const easEnabled = await confirm({


### PR DESCRIPTION
# [cli] Added redux as a state management option


## Description
1. Added redux as an option to cli
2. Wrapped every navigation into Provider
3. Created a  template with a demo store

## Motivation and Context
Redux is still one of the most popular state management solutions used in production, with @reduxjs/toolkit having 3.6 million daily downloads. However, it takes a lot of effort to set it up due to the large amount of boilerplate code. These changes create a minimal Redux store and configure everything needed to start working with Redux immediately.

## How Has This Been Tested?
Tested using `bun run test` and manually tested each option.



