### PR TITLE
add option to run setup-ci after project is created

### DIFF
--- a/.changeset/funny-ghosts-explain.md
+++ b/.changeset/funny-ghosts-explain.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+add option to run setup-ci after project is created

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -6,6 +6,7 @@ import { getPackageManager, getPackageManagerRunnerX } from './getPackageManager
 import { easConfigure } from './runEasConfigure';
 import { ONLY_ERRORS, runSystemCommand } from './systemCommand';
 import { generateNWUI } from './generateNWUI';
+import { runSetupCI } from './runSetupCI';
 
 export async function printOutput(
   cliResults: CliResults,
@@ -126,6 +127,10 @@ export async function printOutput(
 
   if (cliResults.flags.eas) {
     await easConfigure(cliResults, packageManager, toolbox);
+  }
+
+  if (process.env.RUN_SETUP_CI === 'true') {
+    await runSetupCI(toolbox, cliResults);
   }
 
   const printVexoSteps = () => {

--- a/cli/src/utilities/runCLI.ts
+++ b/cli/src/utilities/runCLI.ts
@@ -14,6 +14,7 @@ import {
 } from '../types';
 import { loadConfigs, saveConfig } from './configStorage';
 import { getDefaultPackageManagerVersion } from './getPackageManager';
+import { isProjectCompatibleWithSetupCI } from './runSetupCI';
 
 // based on eas default bun version https://docs.expo.dev/build-reference/infrastructure/#ios-server-images
 const minBunVersion = '1.1.13'; // or greater
@@ -386,6 +387,26 @@ export async function runCLI(toolbox: Toolbox, projectName: string): Promise<Cli
     }
 
     await saveConfig({ name, cliResults });
+  }
+
+  // Ask whether setup-ci should be run after the project is created
+  if (isProjectCompatibleWithSetupCI(toolbox, cliResults)) {
+    const shouldRunSetupCI = await confirm({
+      message: 'Would you like to run setup-ci to bootstrap CI with Github Actions workflows?',
+      initialValue: false
+    });
+
+    if (isCancel(shouldRunSetupCI)) {
+      cancel('Cancelled... 👋');
+      return process.exit(0);
+    }
+
+    if (shouldRunSetupCI) {
+      process.env.RUN_SETUP_CI = 'true';
+      success(`We'll run setup-ci after the project is created.`);
+    } else {
+      success(`No problem, skipping setup-ci for now.`);
+    }
   }
 
   return cliResults;

--- a/cli/src/utilities/runSetupCI.ts
+++ b/cli/src/utilities/runSetupCI.ts
@@ -1,0 +1,29 @@
+import { Toolbox } from 'gluegun/build/types/domain/toolbox';
+import { getPackageManager } from './getPackageManager';
+import { CliResults } from '../types';
+
+const SUPPORTED_PACKAGE_MANAGERS = ['yarn', 'npm'];
+
+export async function isProjectCompatibleWithSetupCI(toolbox: Toolbox, cliResults: CliResults) {
+  const packageManager = getPackageManager(toolbox, cliResults);
+  const { noGit, noInstall } = cliResults.flags;
+
+  return !noGit && !noInstall && SUPPORTED_PACKAGE_MANAGERS.includes(packageManager);
+}
+
+export async function runSetupCI(toolbox: Toolbox, cliResults: CliResults) {
+  const {
+    print: { info },
+    system
+  } = toolbox;
+
+  const { projectName } = cliResults;
+
+  info(``);
+  info('Running setup-ci...');
+
+  await system.spawn(`cd ${projectName} && npx setup-ci@latest`, {
+    shell: true,
+    stdio: 'inherit'
+  });
+}


### PR DESCRIPTION
## Description

This PR is a proposition of how `create-expo-stack` could integrate with [setup-ci](https://github.com/software-mansion/setup-ci). It adds a prompt asking the user whether they want to bootstrap CI using `setup-ci` after the project is created and runs `setup-ci` in a subprocess at the end if the answer was "Yes".

Some details:

- we don't add the `setup-ci` option to config, therefore the prompt appears after the user is asked whether they want to save their configuration,
- the prompt only appears if `noInstall == false`, `noGit == false` and `packageManager` is `yarn` or `npm`, these are requirements for `setup-ci` to work in the generated project,
- if the user decides to run `setup-ci`, an env variable is set `process.env.RUN_SETUP_CI = 'true'`, which is later read to decide whether the script should be run - this way we don't add new fields to `cliResults`, which would in turn alter the project configuration interface.

## Demo

https://github.com/user-attachments/assets/5e8a1084-0fd4-4a3c-9cbd-6a0076bb3d9e

## How Has This Been Tested?

- create-expo-stack version: `2.11.24`
- setup-ci version: `0.6.0`
- OS: `macOS Sonoma 14.7`

Verified that `npx setup-ci` finishes execution successfully and generates all CI workflows when run on projects created with `create-expo-stack` using following configurations.

```
npx create-expo-stack@latest project1 --nativewindui
npx create-expo-stack@latest project2 --react-navigation --tabs --restyle --supabase  --eas
npx create-expo-stack@latest project3 --stylesheet --firebase --yarn
npx create-expo-stack@latest project4 --expo-router --unistyles --supabase --yarn --eas
```