### PR TITLE
fix: expo 52 and react navigation 7

### DIFF
--- a/.changeset/strong-pumpkins-exercise.md
+++ b/.changeset/strong-pumpkins-exercise.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+fix: peer dep errors when using npm and expo 52

--- a/.changeset/strong-pumpkins-exercise.md
+++ b/.changeset/strong-pumpkins-exercise.md
@@ -2,4 +2,4 @@
 'create-expo-stack': patch
 ---
 
-fix: peer dep errors when using npm and expo 52
+fix: compatibility with expo 52 and react navigation 7

--- a/cli/README.md
+++ b/cli/README.md
@@ -59,11 +59,11 @@ Each project is generated based on the results of the CLI, on a per-file basis. 
 
 | Library            | Category            | Version | Description                                    |
 | ------------------ | ------------------- | ------- | ---------------------------------------------- |
-| React Native       | Mobile Framework    | v0.74   | The best cross-platform mobile framework       |
+| React Native       | Mobile Framework    | v0.76   | The best cross-platform mobile framework       |
 | React              | UI Framework        | v18     | The most popular UI framework in the world     |
 | TypeScript         | Language            | v5      | Static typechecking                            |
-| React Navigation   | Navigation          | v6      | Performant and consistent navigation framework |
-| Expo               | SDK                 | v51     | Allows (optional) Expo modules                 |
+| React Navigation   | Navigation          | v7      | Performant and consistent navigation framework |
+| Expo               | SDK                 | v52     | Allows (optional) Expo modules                 |
 | Expo Font          | Custom Fonts        | v11     | Import custom fonts                            |
 | Expo Linking       | URL Handling        | v5      | Open your app via a URL                        |
 | Expo Router        | Navigation          | v3      | File-based routing in React-Native             |

--- a/cli/__tests__/__snapshots__/cli-integration.test.ts.snap
+++ b/cli/__tests__/__snapshots__/cli-integration.test.ts.snap
@@ -39,13 +39,6 @@ exports[`generates a project with --expo-router --nativewind --bun --overwrite: 
     "extends": "universe/native",
     "root": true,
   },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
-  },
   "main": "expo-router/entry",
   "name": "myTestProject",
   "private": true,
@@ -167,13 +160,6 @@ exports[`generates a project with --expo-router --stylesheet --bun --overwrite: 
     "extends": "universe/native",
     "root": true,
   },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
-  },
   "main": "expo-router/entry",
   "name": "myTestProject",
   "private": true,
@@ -291,13 +277,6 @@ exports[`generates a project with --expo-router --tabs --nativewind --bun --over
   "eslintConfig": {
     "extends": "universe/native",
     "root": true,
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
   },
   "main": "expo-router/entry",
   "name": "myTestProject",
@@ -425,13 +404,6 @@ exports[`generates a project with --expo-router --tabs --stylesheet --bun --over
     "extends": "universe/native",
     "root": true,
   },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
-  },
   "main": "expo-router/entry",
   "name": "myTestProject",
   "private": true,
@@ -554,13 +526,6 @@ exports[`generates a project with --expo-router --drawer+tabs --nativewind --bun
   "eslintConfig": {
     "extends": "universe/native",
     "root": true,
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
   },
   "main": "expo-router/entry",
   "name": "myTestProject",
@@ -691,13 +656,6 @@ exports[`generates a project with --expo-router --drawer+tabs --stylesheet --bun
     "extends": "universe/native",
     "root": true,
   },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
-  },
   "main": "expo-router/entry",
   "name": "myTestProject",
   "private": true,
@@ -823,13 +781,6 @@ exports[`generates a project with --expo-router --drawer+tabs --nativewindui --s
   "eslintConfig": {
     "extends": "universe/native",
     "root": true,
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
   },
   "main": "expo-router/entry",
   "name": "myTestProject",
@@ -974,13 +925,6 @@ exports[`generates a project with --expo-router --drawer+tabs --nativewindui --e
   "eslintConfig": {
     "extends": "universe/native",
     "root": true,
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
   },
   "main": "expo-router/entry",
   "name": "myTestProject",
@@ -1132,13 +1076,6 @@ exports[`generates a project with --nativewindui --no-install --bun --overwrite:
     "extends": "universe/native",
     "root": true,
   },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
-  },
   "main": "expo-router/entry",
   "name": "myTestProject",
   "private": true,
@@ -1281,13 +1218,6 @@ exports[`generates a project with --expo-router --drawer+tabs --nativewindui --b
   "eslintConfig": {
     "extends": "universe/native",
     "root": true,
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-safe-area-context",
-      ],
-    },
   },
   "main": "expo-router/entry",
   "name": "myTestProject",

--- a/cli/src/templates/base/components/Button.tsx.ejs
+++ b/cli/src/templates/base/components/Button.tsx.ejs
@@ -1,11 +1,11 @@
 import { forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 
 type ButtonProps = {
   title?: string;
 } & TouchableOpacityProps;
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ title, ...touchableProps }, ref) => {
+export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   return (
     <TouchableOpacity ref={ref} {...touchableProps} style={[styles.button, touchableProps.style]}>
       <Text style={styles.buttonText}>{title}</Text>

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -90,14 +90,14 @@
     <% } %>
 
     <% if (props.navigationPackage?.type === "navigation") { %>
-      "@react-navigation/native": "^6.1.7",
-      "react-native-gesture-handler": "~2.16.1",
-      "react-native-safe-area-context": "4.10.1",
-      "react-native-screens": "3.31.1",
+      "@react-navigation/native": "^7.0.3",
+      "react-native-gesture-handler": "~2.20.2",
+      "react-native-safe-area-context": "4.12.0",
+      "react-native-screens": "~4.1.0",
     <% } %>
 
     <% if (props.navigationPackage?.name === "react-navigation") { %>
-      "@react-navigation/stack": "^6.3.17",
+      "@react-navigation/stack": "^7.0.4",
       "@expo/vector-icons": "^14.0.0",
     <% } %>
 
@@ -110,26 +110,26 @@
     <% } %>
 
     <% if (props.navigationPackage?.options.type === "tabs" && props.navigationPackage?.name === "react-navigation") { %>
-      "@react-navigation/bottom-tabs": "^6.5.8",
+      "@react-navigation/bottom-tabs": "^7.0.5",
     <% } %>
 
     <% if ((props.navigationPackage?.options.type === "drawer + tabs") && (props.navigationPackage?.name === "react-navigation")) { %>
-      "@react-navigation/drawer": "^6.6.15",
-      "@react-navigation/bottom-tabs": "^6.5.8",
+      "@react-navigation/drawer": "^7.0.0",
+      "@react-navigation/bottom-tabs": "^7.0.5",
       "react-native-reanimated": "~3.10.1",
     <% } else if (props.navigationPackage?.options.type === "drawer + tabs") { %>
-      "@react-navigation/drawer": "^6.6.15",
-      "@react-navigation/bottom-tabs": "^6.5.8",
+      "@react-navigation/drawer": "^7.0.0",
+      "@react-navigation/bottom-tabs": "^7.0.5",
     <% } %>
     
     <% if (props.navigationPackage?.name === "expo-router") { %>
       "@expo/vector-icons": "^14.0.0",
       "expo-linking": "~6.3.1",
-      "expo-router": "~3.5.14", 
+      "expo-router": "~4.0.6", 
       "expo-constants": "~16.0.1",     
       "expo-system-ui": "~3.0.4",
       "expo-web-browser": "~13.0.3",
-      "react-dom": "18.2.0",
+      "react-dom": "18.3.1",
       "react-native-reanimated": "~3.10.1",
       "react-native-web": "~0.19.10",
     <% } %>
@@ -153,10 +153,10 @@
     "expo-dev-launcher": "^4.0.22",      
   <% } %>
 
-    "expo": "^51.0.0",
+    "expo": "^52.0.7",
     "expo-status-bar": "~1.12.1",
-    "react": "18.2.0",
-    "react-native": "0.74.1"
+    "react": "18.3.1",
+    "react-native": "0.76.1"
   },
   "devDependencies": {
   <%# patch for this issue : https://github.com/expo/expo/issues/26641 %>
@@ -164,7 +164,7 @@
 	  "ajv": "^8.12.0",
 	<% } %>
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.2.45",
+    "@types/react": "~18.3.12",
     "@typescript-eslint/eslint-plugin": "^7.7.0",
     "@typescript-eslint/parser": "^7.7.0",
     "eslint": "^8.57.0",
@@ -185,13 +185,6 @@
   },
   <% if (props.navigationPackage?.name !== "expo-router") { %>
     "main": "node_modules/expo/AppEntry.js",
-  <% } %>
-  <% if (props.navigationPackage?.type === "navigation") { %>
-    "expo": {
-      "install": {
-        "exclude": ["react-native-safe-area-context"]
-      }
-    },
   <% } %>
   "private": true
 }

--- a/cli/src/templates/packages/nativewind/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/nativewind/components/Button.tsx.ejs
@@ -1,11 +1,11 @@
 import { forwardRef } from 'react';
-import { Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 
 type ButtonProps = {
   title: string;
 } & TouchableOpacityProps;
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ title, ...touchableProps }, ref) => {
+export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   return (
     <TouchableOpacity ref={ref} {...touchableProps} className={`${styles.button} ${touchableProps.className}`}>
       <Text className={styles.buttonText}>{title}</Text>

--- a/cli/src/templates/packages/nativewindui/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/Button.tsx.ejs
@@ -1,11 +1,11 @@
 import { forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 
 type ButtonProps = {
   title?: string;
 } & TouchableOpacityProps;
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ title, ...touchableProps }, ref) => {
+export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   return (
     <TouchableOpacity ref={ref} {...touchableProps} style={[styles.button, touchableProps.style]}>
       <Text style={styles.buttonText}>{title}</Text>

--- a/cli/src/templates/packages/nativewindui/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/drawer/app/_layout.tsx.ejs
@@ -60,7 +60,7 @@ export default function RootLayout() {
 }
 
 const SCREEN_OPTIONS = {
-  animation: 'ios', // for android
+  animation: 'ios_from_right', // for android
 } as const;
 
 const DRAWER_OPTIONS = {

--- a/cli/src/templates/packages/nativewindui/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/stack/app/_layout.tsx.ejs
@@ -63,7 +63,7 @@ export default function RootLayout() {
 }
 
 const SCREEN_OPTIONS = {
-  animation: 'ios', // for android
+  animation: 'ios_from_right', // for android
 } as const;
 
 const INDEX_OPTIONS = {

--- a/cli/src/templates/packages/nativewindui/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/_layout.tsx.ejs
@@ -63,7 +63,7 @@ export default function RootLayout() {
 }
 
 const SCREEN_OPTIONS = {
-  animation: 'ios', // for android
+  animation: 'ios_from_right', // for android
 } as const;
 
 const TABS_OPTIONS = {

--- a/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
+++ b/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
@@ -1,7 +1,8 @@
 import { Theme } from '@react-navigation/native';
+import { DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { COLORS } from './colors';
 
-const NAV_THEME: { light: Partial<Theme>; dark: Partial<Theme> } = {
+const NAV_THEME = {
   light: {
     dark: false,
     colors: {
@@ -12,6 +13,7 @@ const NAV_THEME: { light: Partial<Theme>; dark: Partial<Theme> } = {
       primary: COLORS.light.primary,
       text: COLORS.black,
     },
+    fonts: DefaultTheme.fonts,
   },
   dark: {
     dark: true,
@@ -23,6 +25,7 @@ const NAV_THEME: { light: Partial<Theme>; dark: Partial<Theme> } = {
       primary: COLORS.dark.primary,
       text: COLORS.white,
     },
+     fonts: DarkTheme.fonts,
   },
 };
 

--- a/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
+++ b/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
@@ -1,7 +1,7 @@
 import { Theme } from '@react-navigation/native';
 import { COLORS } from './colors';
 
-const NAV_THEME: { light: Theme; dark: Theme } = {
+const NAV_THEME: { light: Partial<Theme>; dark: Partial<Theme> } = {
   light: {
     dark: false,
     colors: {

--- a/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
+++ b/cli/src/templates/packages/nativewindui/theme/index.ts.ejs
@@ -2,7 +2,7 @@ import { Theme } from '@react-navigation/native';
 import { DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { COLORS } from './colors';
 
-const NAV_THEME = {
+const NAV_THEME: { light: Theme; dark: Theme } = {
   light: {
     dark: false,
     colors: {

--- a/cli/src/templates/packages/restyle/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/restyle/components/Button.tsx.ejs
@@ -1,12 +1,12 @@
 import { forwardRef } from 'react';
-import { TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 import { Text, makeStyles } from 'theme';
 
 type ButtonProps = {
   title?: string;
 } & TouchableOpacityProps;
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ title, ...touchableProps }, ref) => {
+export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   const styles = useStyles();
 
   return (

--- a/cli/src/templates/packages/unistyles/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/Button.tsx.ejs
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import { Text, TouchableOpacity, TouchableOpacityProps } from 'react-native';
+import { Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
 import { useStyles } from 'react-native-unistyles';
 
 type ButtonProps = {
@@ -7,7 +7,7 @@ type ButtonProps = {
 } & TouchableOpacityProps;
 
 
-export const Button = forwardRef<TouchableOpacity, ButtonProps>(({ title, ...touchableProps }, ref) => {
+export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   const { theme } = useStyles();
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

I basically just updated the versions and then tried to fix the types that broke

Generated summary:

### Dependency Updates

* Updated React Native to version 0.76 and React to version 18.3 in `cli/README.md` and `cli/src/templates/base/package.json.ejs`. [[1]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabL62-R66) [[2]](diffhunk://#diff-87b23c3174a1077b26fad3f9cab0268cea77a905deac5cf02ecfd29031ef89f7L156-R167)
* Upgraded `expo` SDK to version 52 in `cli/README.md` and `cli/src/templates/base/package.json.ejs`. [[1]](diffhunk://#diff-a60fd8fcc968f85dd50305193d1af8e94118afb7439f90c07bb434acd3490fabL62-R66) [[2]](diffhunk://#diff-87b23c3174a1077b26fad3f9cab0268cea77a905deac5cf02ecfd29031ef89f7L156-R167)
* Updated `react-navigation` packages to the latest versions in `cli/src/templates/base/package.json.ejs`. [[1]](diffhunk://#diff-87b23c3174a1077b26fad3f9cab0268cea77a905deac5cf02ecfd29031ef89f7L93-R100) [[2]](diffhunk://#diff-87b23c3174a1077b26fad3f9cab0268cea77a905deac5cf02ecfd29031ef89f7L113-R132)

### Code Adjustments for Compatibility

* Removed `expo` install exclusions for `react-native-safe-area-context` across multiple test snapshot files to align with updated dependencies. [[1]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L42-L48) [[2]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L170-L176) [[3]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L295-L301) [[4]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L428-L434) [[5]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L558-L564) [[6]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L694-L700) [[7]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L827-L833) [[8]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L978-L984) [[9]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L1135-L1141) [[10]](diffhunk://#diff-0af14ceeb3a1e79b430f8001b3916c16acd08c1bb8c27a731fce353f660b8877L1285-L1291)
* Updated `Button` component definitions to use `View` instead of `TouchableOpacity` in various template files to fix type error with the latest React Native version. [[1]](diffhunk://#diff-e50af355e8afb186248778806d89d081a8a8a16aa504d315ec27338ed6350fffL2-R8) [[2]](diffhunk://#diff-25981e30a5aa1f2ee7b9cf48b89470d3cdaab33171bb98068a3fa2c09cb9069dL2-R8) [[3]](diffhunk://#diff-e50af355e8afb186248778806d89d081a8a8a16aa504d315ec27338ed6350fffL2-R8) [[4]](diffhunk://#diff-4b68773c905659da0e7112b7f1fc61726a2fc4efb6e566f7c157612618677438L2-R9) [[5]](diffhunk://#diff-b54ed7b5e4ec60c9badd1d8a56acd8dd4791285f8d8341bdc53f0e5df2f3a294L2-R10)

### Configuration and Theming

* Added `fonts` property to navigation themes in `cli/src/templates/packages/nativewindui/theme/index.ts.ejs` to support type changes in react navigation 7. [[1]](diffhunk://#diff-21c56da4aca405b53ea267f1ad5e8ea074e8b8969a0d7e8519160f6eddd5bdd4R2-R5) [[2]](diffhunk://#diff-21c56da4aca405b53ea267f1ad5e8ea074e8b8969a0d7e8519160f6eddd5bdd4R16) [[3]](diffhunk://#diff-21c56da4aca405b53ea267f1ad5e8ea074e8b8969a0d7e8519160f6eddd5bdd4R28)
* Changed the `animation` property for screen options to `ios_from_right` in various layout files to match new option name in react navigation. [[1]](diffhunk://#diff-6b114d6770fc4c7006dbfd1d8aabdcb7f02b204feab68b491681b1e6cbbe292dL63-R63) [[2]](diffhunk://#diff-34d9e184535524da3dae3106883df21cf98fadeff0e3fb736892f2f0812268d7L66-R66) [[3]](diffhunk://#diff-c3da74ad5303a31269992a27e2b861b6ed0a04fb1c8608aab0d735b58b9f101dL66-R66)
