### PR TITLE
[cli] Update tailwind.config.js.ejs to enable manual toggle of dark mode

### DIFF
--- a/.changeset/famous-ants-sell.md
+++ b/.changeset/famous-ants-sell.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+Add `darkMode: class` to tailwing.config.js to manually switch darkMode

--- a/cli/src/templates/packages/nativewindui/tailwind.config.js.ejs
+++ b/cli/src/templates/packages/nativewindui/tailwind.config.js.ejs
@@ -3,6 +3,7 @@ const { hairlineWidth, platformSelect } = require('nativewind/theme');
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   // NOTE: Update this to include the paths to all of your component files.
+  darkMode: 'class', // Enable manual toggling of dark mode
   content: ['./app/**/*.{js,jsx,ts,tsx}', './components/**/*.{js,jsx,ts,tsx}'],
   presets: [require('nativewind/preset')],
   theme: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->
Without this config, I get this error when trying to toggle darkmode in NativeWindUi in `Web` mode
```
Uncaught Error
Unable to manually set color scheme without using darkMode: class. See: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
```

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
steps to reproduce:
1.  npx create-expo-stack@latest
2. choose NativeWindUi
3. Try to toggle dark mode in `Web` mode
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
dark mode doesn't work without this change
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Just tested that the toggle works 

## Screenshots (if appropriate):
