### PR TITLE
feat: add support for Unistyles 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 npm-debug.log
 coverage
 .nyc_output
+.idea
 dist
 build
 myTestProject

--- a/cli/README.md
+++ b/cli/README.md
@@ -74,7 +74,7 @@ Each project is generated based on the results of the CLI, on a per-file basis. 
 | NativeWind         | UI Framework        | v4.1    | Tailwind CSS for React Native                  |
 | Restyle            | UI Framework        | v2      | Theme-based styling library for React Native   |
 | Tamagui            | UI Framework        | v1      | Universal UI with a smart optimizing compiler  |
-| Unistyles          | UI Framework        | v2      | Superset of StyleSheet                         |
+| Unistyles          | UI Framework        | v3      | Superset of StyleSheet                         |
 | Safe Area Context  | Safe Area Library   | v4      | Safe area support                              |
 | React Native Web   | Web Support         | v0.19   | React Native for Web                           |
 | Firebase           | Backend and Auth    | v10     | Cloud-hosted NoSQL database from Google        |

--- a/cli/src/templates/base/App.tsx.ejs
+++ b/cli/src/templates/base/App.tsx.ejs
@@ -1,3 +1,6 @@
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import './unistyles';
+<% } %>
 import { ScreenContent } from 'components/ScreenContent';
 import { StatusBar } from 'expo-status-bar';
 
@@ -29,7 +32,7 @@ import { StatusBar } from 'expo-status-bar';
 <% } %>
 
 <% if (props.stylingPackage?.name === "restyle") {%>
-  export default function App() {   
+  export default function App() {
     return (
       <ThemeProvider theme={theme}>
         <ScreenContent title="Home" path="App.tsx">

--- a/cli/src/templates/base/app.json.ejs
+++ b/cli/src/templates/base/app.json.ejs
@@ -3,6 +3,9 @@
     "name": "<%= props.projectName %>",
     "slug": "<%= props.projectName %>",
     "version": "1.0.0",
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+        "newArchEnabled": true,
+    <% } %>
     <% if (props.navigationPackage?.name === 'expo-router') { %>
       "scheme": "<%= props.projectName %>",
       "web": {
@@ -58,7 +61,7 @@
     <% } %>
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    <% if (props.stylingPackage?.name === "nativewindui") { %>
+    <% if (props.stylingPackage?.name === "nativewindui" || props.stylingPackage?.name === "unistyles") { %>
     "userInterfaceStyle": "automatic",
      <% } else { %>
      "userInterfaceStyle": "light",

--- a/cli/src/templates/base/babel.config.js.ejs
+++ b/cli/src/templates/base/babel.config.js.ejs
@@ -1,7 +1,7 @@
 module.exports = function(api) {
   api.cache(true);
   let plugins = [];
-  
+
   <% if (props.stylingPackage?.name === "tamagui") { %>
     plugins.push([
       '@tamagui/babel-plugin',
@@ -11,6 +11,16 @@ module.exports = function(api) {
       },
     ]);
   <% } %>
+
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+        plugins.push([
+            'react-native-unistyles/plugin',
+            {
+                autoProcessRoot: 'app',
+                autoProcessImports: ['~/components']
+            }
+        ]);
+    <% } %>
 
   <% if (props.navigationPackage?.options.type === "drawer + tabs") { %>
     plugins.push('react-native-reanimated/plugin');

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -89,7 +89,7 @@
     <% } %>
 
     <% if (props.stylingPackage?.name === "unistyles") { %>
-        "react-native-unistyles": "3.0.0-nightly-20250219",
+        "react-native-unistyles": "3.0.0-nightly-20250220",
         "react-native-nitro-modules": "0.22.1",
         "react-native-edge-to-edge": "1.4.3",
     <% } %>

--- a/cli/src/templates/base/package.json.ejs
+++ b/cli/src/templates/base/package.json.ejs
@@ -1,9 +1,11 @@
 {
   "name": "<%= props.projectName %>",
   "version": "1.0.0",
-  <% if (props.navigationPackage?.name === "expo-router") { %>
-  "main": "expo-router/entry",
-  <% } %>
+<% if (props.navigationPackage?.name === "expo-router" && props.stylingPackage?.name === 'unistyles') { %>
+    "main": "index.js",
+<% } else if (props.navigationPackage?.name === "expo-router") { %>
+    "main": "expo-router/entry",
+<% } %>
   "scripts": {
   <% if (props.flags?.eas) { %>
     "start": "expo start --dev-client",
@@ -71,7 +73,7 @@
     <% if (props.stateManagementPackage?.name === "zustand") { %>
       "zustand": "^4.5.1",
     <% } %>
-    
+
     <% if (props.stylingPackage?.name === "restyle") { %>
       "@shopify/restyle": "^2.4.2",
     <% } %>
@@ -87,7 +89,9 @@
     <% } %>
 
     <% if (props.stylingPackage?.name === "unistyles") { %>
-      "react-native-unistyles": "^2.1.1",
+        "react-native-unistyles": "3.0.0-nightly-20250219",
+        "react-native-nitro-modules": "0.22.1",
+        "react-native-edge-to-edge": "1.4.3",
     <% } %>
 
     <% if (props.navigationPackage?.type === "navigation") { %>
@@ -122,12 +126,12 @@
       "@react-navigation/drawer": "^7.0.0",
       "@react-navigation/bottom-tabs": "^7.0.5",
     <% } %>
-    
+
     <% if (props.navigationPackage?.name === "expo-router") { %>
       "@expo/vector-icons": "^14.0.0",
       "expo-linking": "~6.3.1",
-      "expo-router": "~4.0.6", 
-      "expo-constants": "~16.0.1",     
+      "expo-router": "~4.0.6",
+      "expo-constants": "~16.0.1",
       "expo-system-ui": "~3.0.4",
       "expo-web-browser": "~13.0.3",
       "react-dom": "18.3.1",
@@ -143,15 +147,15 @@
 	<% if (props.authenticationPackage?.name === "firebase") { %>
 	  "firebase": "^10.5.2",
 	<% } %>
-  
+
   <% if (props.internalizationPackage?.name === "i18next") { %>
     "i18next": "^23.7.20",
     "react-i18next": "^14.0.1",
     "expo-localization": "~14.8.3",
-  <% } %> 
+  <% } %>
   <% if (props.flags?.eas || props.stylingPackage?.name === "nativewindui") { %>
     "expo-dev-client": "~5.0.4",
-    "expo-dev-launcher": "^5.0.17",      
+    "expo-dev-launcher": "^5.0.17",
   <% } %>
 
     "expo": "^52.0.7",

--- a/cli/src/templates/packages/expo-router/drawer/app/(drawer)/(tabs)/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/(drawer)/(tabs)/_layout.tsx.ejs
@@ -1,13 +1,25 @@
 import { Tabs } from 'expo-router';
 import { TabBarIcon } from '~/components/TabBarIcon';
-
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { useUnistyles } from "react-native-unistyles";
+<% } %>
 
 export default function TabLayout() {
+<% if (props.stylingPackage?.name === "unistyles") { %>
+  const { theme } = useUnistyles();
+<% } %>
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+        tabBarActiveTintColor: theme.colors.astral,
+        tabBarStyle: {
+          backgroundColor: theme.colors.background,
+        }
+        <% } else { %>
         tabBarActiveTintColor: 'black',
+        <% } %>
       }}>
       <Tabs.Screen
         name="index"

--- a/cli/src/templates/packages/expo-router/drawer/app/(drawer)/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/(drawer)/_layout.tsx.ejs
@@ -1,35 +1,65 @@
 import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { Link } from 'expo-router';
 import { Drawer } from 'expo-router/drawer';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { useUnistyles } from "react-native-unistyles";
+<% } %>
 
 import { HeaderButton } from '../../components/HeaderButton';
 
-const DrawerLayout = () => (
-  <Drawer>
-    <Drawer.Screen
-      name="index"
-      options={{
-        headerTitle: 'Home',
-        drawerLabel: 'Home',
-        drawerIcon: ({ size, color }) => <Ionicons name="home-outline" size={size} color={color} />,
-      }}
-    />
-    <Drawer.Screen
-      name="(tabs)"
-      options={{
-        headerTitle: 'Tabs',
-        drawerLabel: 'Tabs',
-        drawerIcon: ({ size, color }) => (
-          <MaterialIcons name="border-bottom" size={size} color={color} />
-        ),
-        headerRight: () => (
-          <Link href="/modal" asChild>
-            <HeaderButton />
-          </Link>
-        ),
-      }}
-    />
-  </Drawer>
-);
+const DrawerLayout = () => {
+<% if (props.stylingPackage?.name === "unistyles") { %>
+    const { theme } = useUnistyles();
+<% } %>
+
+    return (
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+        <Drawer
+            screenOptions={{
+                headerStyle: {
+                    backgroundColor: theme.colors.background,
+                },
+                headerTitleStyle: {
+                    color: theme.colors.typography,
+                },
+                headerTintColor: theme.colors.typography,
+                drawerStyle: {
+                    backgroundColor: theme.colors.background,
+                },
+                drawerLabelStyle: {
+                    color: theme.colors.typography,
+                },
+                drawerInactiveTintColor: theme.colors.typography,
+            }}
+        >
+            <% } else  { %>
+        <Drawer>
+        <% } %>
+            <Drawer.Screen
+                name="index"
+                options={{
+                    headerTitle: 'Home',
+                    drawerLabel: 'Home',
+                    drawerIcon: ({ size, color }) => <Ionicons name="home-outline" size={size} color={color} />,
+                }}
+            />
+            <Drawer.Screen
+                name="(tabs)"
+                options={{
+                    headerTitle: 'Tabs',
+                    drawerLabel: 'Tabs',
+                    drawerIcon: ({ size, color }) => (
+                        <MaterialIcons name="border-bottom" size={size} color={color} />
+                    ),
+                    headerRight: () => (
+                        <Link href="/modal" asChild>
+                            <HeaderButton />
+                        </Link>
+                    ),
+                }}
+            />
+        </Drawer>
+    );
+}
 
 export default DrawerLayout;

--- a/cli/src/templates/packages/expo-router/drawer/app/+html.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/+html.tsx.ejs
@@ -1,4 +1,7 @@
 import { ScrollViewStyleReset } from 'expo-router/html';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+    import '../unistyles';
+<% } %>
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.
@@ -11,7 +14,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 
-        {/* 
+        {/*
           This viewport disables scaling which makes the mobile website act more like a native app.
           However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
             <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -20,8 +23,8 @@ export default function Root({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
         />
-        {/* 
-          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native. 
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
         */}
         <ScrollViewStyleReset />

--- a/cli/src/templates/packages/expo-router/drawer/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/+not-found.tsx.ejs
@@ -4,7 +4,7 @@ import { Link, Stack } from 'expo-router';
 
   import { Container } from '~/components/Container';
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  import { createStyleSheet, useStyles } from 'react-native-unistyles'
+  import { StyleSheet } from 'react-native-unistyles'
   import { Text } from 'react-native';
 
   import { Container } from '~/components/Container';
@@ -24,8 +24,6 @@ import { Link, Stack } from 'expo-router';
 export default function NotFoundScreen() {
 <% if (props.stylingPackage?.name === "restyle") { %>
   const styles = useStyles();
-<% } else if (props.stylingPackage?.name === "unistyles") {%>
-  const { styles } = useStyles(stylesheet);
 <% } %>
 
   return (
@@ -84,10 +82,11 @@ export default function NotFoundScreen() {
     linkText: `text-base text-[#2e78b7]`,
 	};
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  const stylesheet = createStyleSheet((theme) => ({
+  const styles = StyleSheet.create((theme) => ({
     title: {
       fontSize: 20,
       fontWeight: 'bold',
+      color: theme.colors.typography,
     },
     link: {
       marginTop: 16,

--- a/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/drawer/app/_layout.tsx.ejs
@@ -4,9 +4,6 @@
   import '../global.css';
   import 'expo-dev-client';
 <% } %>
-<% if (props.stylingPackage?.name === "unistyles") { %>
-import '../unistyles';
-<% } %>
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
   import '../translation';
@@ -27,8 +24,12 @@ import { Stack } from 'expo-router';
 	SplashScreen.preventAutoHideAsync();
 <% }  else if (props.stylingPackage?.name === "restyle") { %>
   import { ThemeProvider } from '@shopify/restyle';
-  
+
   import { theme } from '../theme';
+<% } %>
+
+<% if (props.stylingPackage?.name === "unistyles") { %>
+    import { useUnistyles } from "react-native-unistyles";
 <% } %>
 
 <% if (props.analyticsPackage?.name === "vexo-analytics") { %>
@@ -57,6 +58,9 @@ export default function RootLayout() {
 
     if (!loaded) return null;
   <% } %>
+  <% if (props.stylingPackage?.name === "unistyles") { %>
+    const { theme } = useUnistyles();
+  <% } %>
 
   	return (
     	<% if (props.stylingPackage?.name === "tamagui") { %>
@@ -65,7 +69,28 @@ export default function RootLayout() {
     		<ThemeProvider theme={theme}>
     	<% } %>
         <GestureHandlerRootView style={{ flex: 1 }}>
+         <% if (props.stylingPackage?.name === "unistyles") { %>
+            <Stack
+                screenOptions={{
+                    headerStyle: {
+                        backgroundColor: theme.colors.background,
+                    },
+                    headerTitleStyle: {
+                        color: theme.colors.typography,
+                    },
+                    headerTintColor: theme.colors.typography,
+                    drawerStyle: {
+                        backgroundColor: theme.colors.background,
+                    },
+                    drawerLabelStyle: {
+                        color: theme.colors.typography,
+                    },
+                    drawerInactiveTintColor: theme.colors.typography,
+                }}
+            >
+        <% } else  { %>
           <Stack>
+        <% } %>
             <Stack.Screen name="(drawer)" options={{ headerShown: false }} />
             <Stack.Screen name="modal" options={{ title: 'Modal', presentation: 'modal' }} />
           </Stack>

--- a/cli/src/templates/packages/expo-router/index.js.ejs
+++ b/cli/src/templates/packages/expo-router/index.js.ejs
@@ -1,0 +1,4 @@
+<% if (props.stylingPackage?.name === 'unistyles') { %>
+import 'expo-router/entry';
+import './unistyles';
+<% } %>

--- a/cli/src/templates/packages/expo-router/stack/app/+html.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/+html.tsx.ejs
@@ -1,4 +1,7 @@
 import { ScrollViewStyleReset } from 'expo-router/html';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import '../unistyles';
+<% } %>
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.
@@ -11,7 +14,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 
-        {/* 
+        {/*
           This viewport disables scaling which makes the mobile website act more like a native app.
           However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
             <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -20,8 +23,8 @@ export default function Root({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
         />
-        {/* 
-          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native. 
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
         */}
         <ScrollViewStyleReset />

--- a/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
@@ -111,7 +111,7 @@ const styles = StyleSheet.create({
       fontSize: 14,
       color: '#2e78b7',
     },
-}));
+});
 <% } else if (props.stylingPackage?.name === "restyle") { %>
   const useStyles = makeStyles((theme) => ({
     link: {

--- a/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
@@ -4,7 +4,7 @@ import { Link, Stack } from 'expo-router';
 
   import { Container } from '~/components/Container';
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  import { createStyleSheet, useStyles } from 'react-native-unistyles'
+  import { StyleSheet } from 'react-native-unistyles'
   import { Text } from 'react-native';
 
   import { Container } from '~/components/Container';
@@ -24,10 +24,6 @@ import { Link, Stack } from 'expo-router';
 export default function NotFoundScreen() {
 <% if (props.stylingPackage?.name === "restyle") { %>
   const styles = useStyles();
-<% } %>
-
-<% if (props.stylingPackage?.name === "unistyles") {%>
-  const { styles } = useStyles(stylesheet)
 <% } %>
 
   return (
@@ -86,10 +82,11 @@ export default function NotFoundScreen() {
     linkText: `text-base text-[#2e78b7]`,
 	};
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  const stylesheet = createStyleSheet({
+  const styles = StyleSheet.create((theme) => ({
     title: {
       fontSize: 20,
       fontWeight: 'bold',
+      color: theme.colors.typography,
     },
     link: {
       marginTop: 16,
@@ -97,7 +94,7 @@ export default function NotFoundScreen() {
     },
     linkText: {
       fontSize: 14,
-      color: '#2e78b7',
+      color: theme.colors.astral
     },
   });
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>

--- a/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/+not-found.tsx.ejs
@@ -82,7 +82,7 @@ export default function NotFoundScreen() {
     linkText: `text-base text-[#2e78b7]`,
 	};
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  const styles = StyleSheet.create((theme) => ({
+const styles = StyleSheet.create((theme) => ({
     title: {
       fontSize: 20,
       fontWeight: 'bold',
@@ -96,9 +96,9 @@ export default function NotFoundScreen() {
       fontSize: 14,
       color: theme.colors.astral
     },
-  });
+}));
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
-  const styles = StyleSheet.create({
+const styles = StyleSheet.create({
     title: {
       fontSize: 20,
       fontWeight: 'bold',
@@ -111,7 +111,7 @@ export default function NotFoundScreen() {
       fontSize: 14,
       color: '#2e78b7',
     },
-  });
+}));
 <% } else if (props.stylingPackage?.name === "restyle") { %>
   const useStyles = makeStyles((theme) => ({
     link: {

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -3,7 +3,7 @@
 <% } %>
 
 <% if (props.stylingPackage?.name === "unistyles") { %>
-import '../unistyles';
+  import { useUnistyles } from "react-native-unistyles";
 <% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
   import '../translation';
@@ -29,7 +29,9 @@ import '../unistyles';
 <% } %>
 
 export default function Layout() {
-
+  <% if (props.stylingPackage?.name === "unistyles") { %>
+    const { theme } = useUnistyles();
+  <% } %>
   <% if (props.stylingPackage?.name === "tamagui") { %>
   	const [loaded] = useFonts({
 			Inter: require("@tamagui/font-inter/otf/Inter-Medium.otf"),
@@ -51,7 +53,20 @@ export default function Layout() {
 		<% } else if (props.stylingPackage?.name === "restyle") { %>
 			<ThemeProvider theme={theme}>
 		<% } %>
-		    <Stack />
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+            <Stack
+                screenOptions={{
+                    headerStyle: {
+                        backgroundColor: theme.colors.background,
+                    },
+                    headerTitleStyle: {
+                        color: theme.colors.typography,
+                    }
+                }}
+            />
+        <% } else { %>
+            <Stack />
+        <% } %>
 		<% if (props.stylingPackage?.name === "tamagui") { %>
 			</TamaguiProvider>
 		<% } else if (props.stylingPackage?.name === "restyle") { %>

--- a/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/_layout.tsx.ejs
@@ -61,7 +61,8 @@ export default function Layout() {
                     },
                     headerTitleStyle: {
                         color: theme.colors.typography,
-                    }
+                    },
+                    headerTintColor: theme.colors.typography
                 }}
             />
         <% } else { %>

--- a/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/stack/app/index.tsx.ejs
@@ -1,5 +1,9 @@
 import { Stack, Link } from 'expo-router';
 
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { StyleSheet } from 'react-native-unistyles';
+<% } %>
+
 import { Button } from '~/components/Button';
 import { Container } from '~/components/Container';
 import { ScreenContent } from '~/components/ScreenContent';
@@ -19,9 +23,21 @@ export default function Home() {
         <% } %>
         </ScreenContent>
         <Link href={{ pathname: '/details', params: { name: 'Dan' } }} asChild>
-          <Button title="Show Details" />
+          <% if (props.stylingPackage?.name === "unistyles") { %>
+              <Button title="Show Details" style={styles.button} />
+          <% } else { %>
+              <Button title="Show Details" />
+          <% } %>
         </Link>
       </Container>
     </>
   );
 }
+
+<% if (props.stylingPackage?.name === "unistyles") { %>
+const styles = StyleSheet.create((theme) => ({
+    button: {
+        marginHorizontal: theme.margins.xl,
+    },
+}));
+<% } %>

--- a/cli/src/templates/packages/expo-router/tabs/app/(tabs)/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/(tabs)/_layout.tsx.ejs
@@ -1,14 +1,31 @@
 import { Link, Tabs } from "expo-router";
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { useUnistyles } from "react-native-unistyles";
+<% } %>
 import { HeaderButton } from '../../components/HeaderButton';
 import { TabBarIcon } from '../../components/TabBarIcon';
 
-
-
 export default function TabLayout() {
+<% if (props.stylingPackage?.name === "unistyles") { %>
+  const { theme } = useUnistyles();
+<% } %>
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: 'black',
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+          headerStyle: {
+            backgroundColor: theme.colors.background,
+          },
+          headerTitleStyle: {
+            color: theme.colors.typography,
+          },
+          tabBarActiveTintColor: theme.colors.astral,
+          tabBarStyle: {
+             backgroundColor: theme.colors.background,
+          },
+          <% } else { %>
+          tabBarActiveTintColor: 'black',
+        <% } %>
       }}>
       <Tabs.Screen
         name='index'

--- a/cli/src/templates/packages/expo-router/tabs/app/(tabs)/index.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/(tabs)/index.tsx.ejs
@@ -1,5 +1,10 @@
 import { Stack } from 'expo-router';
+<% if (props.stylingPackage?.name === 'unistyles') { %>
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+<% } else { %>
 import { StyleSheet, View } from 'react-native';
+<% } %>
 
 import { ScreenContent } from '~/components/ScreenContent';
 
@@ -14,9 +19,19 @@ export default function Home() {
   );
 }
 
+<% if (props.stylingPackage?.name === 'unistyles') { %>
+const styles = StyleSheet.create(theme => ({
+    container: {
+        flex: 1,
+        padding: 24,
+        backgroundColor: theme.colors.background,
+    },
+}));
+<% } else { %>
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
+    container: {
+        flex: 1,
+        padding: 24,
+    },
 });
+<% } %>

--- a/cli/src/templates/packages/expo-router/tabs/app/(tabs)/two.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/(tabs)/two.tsx.ejs
@@ -1,5 +1,10 @@
 import { Stack } from 'expo-router';
+<% if (props.stylingPackage?.name === 'unistyles') { %>
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+<% } else { %>
 import { StyleSheet, View } from 'react-native';
+<% } %>
 
 import { ScreenContent } from '~/components/ScreenContent';
 
@@ -14,9 +19,19 @@ export default function Home() {
   );
 }
 
+<% if (props.stylingPackage?.name === 'unistyles') { %>
+const styles = StyleSheet.create(theme => ({
+    container: {
+        flex: 1,
+        padding: 24,
+        backgroundColor: theme.colors.background,
+    },
+}));
+<% } else { %>
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
+    container: {
+        flex: 1,
+        padding: 24,
+    },
 });
+<% } %>

--- a/cli/src/templates/packages/expo-router/tabs/app/+html.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/+html.tsx.ejs
@@ -1,4 +1,7 @@
 import { ScrollViewStyleReset } from 'expo-router/html';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+    import '../unistyles';
+<% } %>
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.
@@ -11,7 +14,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 
-        {/* 
+        {/*
           This viewport disables scaling which makes the mobile website act more like a native app.
           However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
             <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -20,8 +23,8 @@ export default function Root({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
         />
-        {/* 
-          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native. 
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
         */}
         <ScrollViewStyleReset />

--- a/cli/src/templates/packages/expo-router/tabs/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/+not-found.tsx.ejs
@@ -2,7 +2,7 @@ import { Link, Stack } from 'expo-router';
 <% if (props.stylingPackage?.name === "nativewind") {%>
   import { Text, View } from 'react-native';
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  import { createStyleSheet, useStyles } from 'react-native-unistyles'
+  import { StyleSheet } from 'react-native-unistyles'
   import { Text, View } from 'react-native';
 <% } else if (props.stylingPackage?.name === "stylesheet") { %>
   import { StyleSheet, Text, View } from 'react-native';
@@ -16,10 +16,6 @@ import { Link, Stack } from 'expo-router';
 export default function NotFoundScreen() {
 <% if (props.stylingPackage?.name === "restyle") { %>
   const styles = useStyles();
-<% } %>
-
-<% if (props.stylingPackage?.name === "unistyles") {%>
-  const { styles } = useStyles(stylesheet);
 <% } %>
 
   return (
@@ -79,7 +75,7 @@ export default function NotFoundScreen() {
     linkText: `text-base text-[#2e78b7]`,
 	};
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
-  const stylesheet = createStyleSheet((theme) => ({
+  const styles = StyleSheet.create((theme) => ({
     container: {
       flex: 1,
       alignItems: 'center',

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -3,6 +3,8 @@
 <% } else if (props.stylingPackage?.name === "nativewinui") { %>
   import '../global.css';
   import 'expo-dev-client';
+<% } else if (props.stylingPackage?.name === "unistyles") { %>
+  import { useUnistyles } from "react-native-unistyles";
 <% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
   import '../translation';
@@ -51,6 +53,9 @@ export default function RootLayout() {
 
     	if (!loaded) return null;
   	<% } %>
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+        const { theme } = useUnistyles();
+    <% } %>
 
   	return (
     	<% if (props.stylingPackage?.name === "tamagui") { %>
@@ -58,7 +63,21 @@ export default function RootLayout() {
     	<% } else if (props.stylingPackage?.name === "restyle") { %>
     		<ThemeProvider theme={theme}>
     	<% } %>
-		<Stack>
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+            <Stack
+                screenOptions={{
+                    headerStyle: {
+                        backgroundColor: theme.colors.background,
+                    },
+                    headerTitleStyle: {
+                        color: theme.colors.typography,
+                    },
+                    headerTintColor: theme.colors.typography
+                }}
+            >
+        <% } else  { %>
+            <Stack>
+        <% } %>
 			<Stack.Screen name="(tabs)" options={{ headerShown: false }} />
 			<Stack.Screen name="modal" options={{ presentation: "modal" }} />
 		</Stack>

--- a/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
+++ b/cli/src/templates/packages/expo-router/tabs/app/_layout.tsx.ejs
@@ -4,9 +4,6 @@
   import '../global.css';
   import 'expo-dev-client';
 <% } %>
-<% if (props.stylingPackage?.name === "unistyles") { %>
-import '../unistyles';
-<% } %>
 <% if (props.internalizationPackage?.name === "i18next") { %>
   import '../translation';
 <% } %>

--- a/cli/src/templates/packages/react-navigation/navigation/drawer-navigator.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/drawer-navigator.tsx.ejs
@@ -2,6 +2,9 @@ import { Ionicons, MaterialIcons } from '@expo/vector-icons';
 import { createDrawerNavigator } from '@react-navigation/drawer';
 import { StackScreenProps } from '@react-navigation/stack';
 import { HeaderButton } from 'components/HeaderButton';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { useUnistyles } from 'react-native-unistyles';
+<% } %>
 
 import { RootStackParamList } from '.';
 import TabNavigator from './tab-navigator';
@@ -12,8 +15,33 @@ type Props = StackScreenProps<RootStackParamList, 'DrawerNavigator'>;
 const Drawer = createDrawerNavigator();
 
 export default function DrawerNavigator({ navigation }: Props) {
+<% if (props.stylingPackage?.name === "unistyles") { %>
+  const { theme } = useUnistyles();
+<% } %>
+
   return (
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+    <Drawer.Navigator
+        screenOptions={{
+            headerStyle: {
+                backgroundColor: theme.colors.background,
+            },
+            headerTitleStyle: {
+                color: theme.colors.typography,
+            },
+            headerTintColor: theme.colors.typography,
+            drawerStyle: {
+                backgroundColor: theme.colors.background,
+            },
+            drawerLabelStyle: {
+                color: theme.colors.typography,
+            },
+            drawerInactiveTintColor: theme.colors.typography,
+        }}
+    >
+    <% } else { %>
     <Drawer.Navigator>
+    <% } %>
       <Drawer.Screen
         name="Home"
         component={Home}

--- a/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
@@ -53,6 +53,9 @@
 <% } else if (props.navigationPackage?.options.type === 'tabs') { %>
 	import { NavigationContainer } from "@react-navigation/native";
 	import { createStackNavigator } from "@react-navigation/stack";
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+        import { useUnistyles } from 'react-native-unistyles';
+    <% } %>
 
 	import Modal from "../screens/modal";
 	import TabNavigator from "./tab-navigator";
@@ -65,9 +68,25 @@
 	const Stack = createStackNavigator<RootStackParamList>();
 
 	export default function RootStack() {
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+        const { theme } = useUnistyles();
+        <% } %>
 		return (
 			<NavigationContainer>
-				<Stack.Navigator initialRouteName="TabNavigator">
+				<Stack.Navigator
+                    initialRouteName="TabNavigator"
+                    <% if (props.stylingPackage?.name === "unistyles") { %>
+                        screenOptions={{
+                            headerStyle: {
+                                backgroundColor: theme.colors.background,
+                            },
+                            headerTitleStyle: {
+                                color: theme.colors.typography,
+                            },
+                            headerTintColor: theme.colors.typography,
+                        }}
+                    <% } %>
+                >
 					<Stack.Screen
 						name="TabNavigator"
 						component={TabNavigator}
@@ -85,6 +104,9 @@
 	<% } else if (props.navigationPackage?.options.type === 'drawer + tabs') { %>
 		import { NavigationContainer } from "@react-navigation/native";
 		import { createStackNavigator } from '@react-navigation/stack';
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+            import { useUnistyles } from 'react-native-unistyles';
+        <% } %>
 
 		import Modal from "../screens/modal";
 		import DrawerNavigator from "./drawer-navigator";
@@ -98,9 +120,25 @@
 		const Stack = createStackNavigator<RootStackParamList>();
 
 		export default function RootStack() {
+            <% if (props.stylingPackage?.name === "unistyles") { %>
+            const { theme } = useUnistyles();
+            <% } %>
 			return (
 				<NavigationContainer>
-					<Stack.Navigator initialRouteName="DrawerNavigator">
+					<Stack.Navigator
+                        initialRouteName="DrawerNavigator"
+                        <% if (props.stylingPackage?.name === "unistyles") { %>
+                        screenOptions={{
+                            headerStyle: {
+                                backgroundColor: theme.colors.background,
+                            },
+                            headerTitleStyle: {
+                                color: theme.colors.typography,
+                            },
+                            headerTintColor: theme.colors.typography,
+                        }}
+                        <% } %>
+                    >
 						<Stack.Screen
 							name="DrawerNavigator"
 							component={DrawerNavigator}

--- a/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/index.tsx.ejs
@@ -2,9 +2,13 @@
 	import { NavigationContainer } from "@react-navigation/native";
 	import { createStackNavigator } from "@react-navigation/stack";
 
+    <% if (props.stylingPackage?.name === "unistyles") { %>
+        import { useUnistyles } from 'react-native-unistyles';
+    <% } %>
+
 	import Overview from "../screens/overview";
 	import Details from "../screens/details";
-  import { BackButton } from '../components/BackButton';
+    import { BackButton } from '../components/BackButton';
 
 	export type RootStackParamList = {
 		Overview: undefined;
@@ -14,10 +18,25 @@
 	const Stack = createStackNavigator<RootStackParamList>();
 
 	export default function RootStack() {
-
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+        const { theme } = useUnistyles();
+        <% } %>
 		return (
 			<NavigationContainer>
-				<Stack.Navigator initialRouteName="Overview">
+				<Stack.Navigator
+                    initialRouteName="Overview"
+                    <% if (props.stylingPackage?.name === "unistyles") { %>
+                    screenOptions={{
+                        headerStyle: {
+                            backgroundColor: theme.colors.background,
+                        },
+                        headerTitleStyle: {
+                            color: theme.colors.typography,
+                        },
+                        headerTintColor: theme.colors.typography,
+                    }}
+                    <% } %>
+                >
 					<Stack.Screen name="Overview" component={Overview} />
 					<Stack.Screen
 						name="Details"
@@ -66,18 +85,18 @@
 	<% } else if (props.navigationPackage?.options.type === 'drawer + tabs') { %>
 		import { NavigationContainer } from "@react-navigation/native";
 		import { createStackNavigator } from '@react-navigation/stack';
-	
+
 		import Modal from "../screens/modal";
 		import DrawerNavigator from "./drawer-navigator";
-	
+
 		export type RootStackParamList = {
 			DrawerNavigator: undefined;
 			Modal: undefined;
       TabNavigator: undefined;
 		};
-	
+
 		const Stack = createStackNavigator<RootStackParamList>();
-	
+
 		export default function RootStack() {
 			return (
 				<NavigationContainer>

--- a/cli/src/templates/packages/react-navigation/navigation/tab-navigator.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/navigation/tab-navigator.tsx.ejs
@@ -1,6 +1,8 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { StackScreenProps } from '@react-navigation/stack';
-
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { useUnistyles } from 'react-native-unistyles';
+<% } %>
 import { RootStackParamList } from '.';
 import { HeaderButton } from '../components/HeaderButton';
 import { TabBarIcon } from '../components/TabBarIcon';
@@ -12,10 +14,26 @@ const Tab = createBottomTabNavigator();
 type Props = StackScreenProps<RootStackParamList, 'TabNavigator'>;
 
 export default function TabLayout({ navigation }: Props) {
+  <% if (props.stylingPackage?.name === "unistyles") { %>
+  const { theme } = useUnistyles();
+  <% } %>
   return (
     <Tab.Navigator
-      screenOptions={{
-        tabBarActiveTintColor: 'black',
+        screenOptions={{
+        <% if (props.stylingPackage?.name === "unistyles") { %>
+            headerStyle: {
+                backgroundColor: theme.colors.background,
+            },
+            headerTitleStyle: {
+                color: theme.colors.typography,
+            },
+            tabBarActiveTintColor: theme.colors.astral,
+            tabBarStyle: {
+                backgroundColor: theme.colors.background,
+            },
+        <% } else { %>
+            tabBarActiveTintColor: 'black',
+        <% } %>
 	    <% if (props.navigationPackage?.options.type === 'drawer + tabs') { %>
         headerShown: false,
       <% } %>

--- a/cli/src/templates/packages/react-navigation/screens/details.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/details.tsx.ejs
@@ -1,6 +1,11 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { ScreenContent } from 'components/ScreenContent';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+<% } else {%>
 import { StyleSheet, View } from 'react-native';
+<% } %>
 
 import { RootStackParamList } from '../navigation';
 
@@ -19,9 +24,20 @@ export default function Details() {
   );
 }
 
+<% if (props.stylingPackage?.name === "unistyles") { %>
+export const styles = StyleSheet.create((theme, rt) => ({
+    container: {
+        flex: 1,
+        padding: 24,
+        backgroundColor: theme.colors.background,
+        paddingBottom: rt.insets.bottom,
+    },
+}));
+<% } else { %>
 export const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
+    container: {
+        flex: 1,
+        padding: 24,
+    },
 });
+<% } %>

--- a/cli/src/templates/packages/react-navigation/screens/overview.tsx.ejs
+++ b/cli/src/templates/packages/react-navigation/screens/overview.tsx.ejs
@@ -1,7 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { ScreenContent } from 'components/ScreenContent';
+<% if (props.stylingPackage?.name === "unistyles") { %>
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
+<% } else {%>
 import { StyleSheet, View } from 'react-native';
+<% } %>
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
   import { InternalizationExample } from 'components/InternalizationExample';
@@ -34,10 +39,20 @@ export default function Overview() {
   );
 }
 
-
+<% if (props.stylingPackage?.name === "unistyles") { %>
+export const styles = StyleSheet.create((theme, rt) => ({
+    container: {
+        flex: 1,
+        padding: 24,
+        backgroundColor: theme.colors.background,
+        paddingBottom: rt.insets.bottom,
+    },
+}));
+<% } else { %>
 export const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
+    container: {
+        flex: 1,
+        padding: 24,
+    },
 });
+<% } %>

--- a/cli/src/templates/packages/unistyles/components/BackButton.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/BackButton.tsx.ejs
@@ -1,26 +1,28 @@
 import { Feather } from '@expo/vector-icons';
 import { Text, View } from 'react-native';
-import { createStyleSheet, useStyles } from 'react-native-unistyles';
+import { StyleSheet, withUnistyles } from 'react-native-unistyles';
+
+const UniFeather = withUnistyles(Feather, theme => ({
+    color: theme.colors.azureRadiance
+}));
 
 export const BackButton = ({ onPress }: { onPress: () => void; }) => {
-  const { styles, theme } = useStyles(stylesheet);
-
-  return (
-    <View style={styles.backButton}>
-      <Feather name="chevron-left" size={16} color={theme.colors.azureRadiance} />
-      <Text style={styles.backButtonText} onPress={onPress}>
-        Back
-      </Text>
-    </View>
-  );
+    return (
+        <View style={styles.backButton}>
+            <UniFeather name="chevron-left" size={16} />
+            <Text style={styles.backButtonText} onPress={onPress}>
+                Back
+            </Text>
+        </View>
+    );
 };
-const stylesheet = createStyleSheet((theme) => ({
-  backButton: {
-    flexDirection: 'row',
-    paddingLeft: 20,
-  },
-  backButtonText: {
-    color: theme.colors.azureRadiance,
-    marginLeft: 4,
-  },
+const styles = StyleSheet.create((theme) => ({
+    backButton: {
+        flexDirection: 'row',
+        paddingLeft: 20,
+    },
+    backButtonText: {
+        color: theme.colors.azureRadiance,
+        marginLeft: 4,
+    },
 }));

--- a/cli/src/templates/packages/unistyles/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/Button.tsx.ejs
@@ -1,18 +1,40 @@
 import { forwardRef } from 'react';
 import { Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
-import { useStyles } from 'react-native-unistyles';
+import { StyleSheet } from 'react-native-unistyles';
 
 type ButtonProps = {
-  title?: string;
+    title?: string;
 } & TouchableOpacityProps;
 
-
 export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
-  const { theme } = useStyles();
-
-  return (
-    <TouchableOpacity ref={ref} {...touchableProps} style={[theme.components.button, touchableProps.style]}>
-      <Text style={theme.components.buttonText}>{title}</Text>
+    return (
+    <TouchableOpacity ref={ref} {...touchableProps} style={[styles.button, touchableProps.style]}>
+        <Text style={styles.buttonText}>{title}</Text>
     </TouchableOpacity>
-  );
+    );
 });
+
+const styles = StyleSheet.create(theme => ({
+    button: {
+        alignItems: 'center',
+        backgroundColor: theme.colors.cornflowerBlue,
+        borderRadius: 24,
+        elevation: 5,
+        flexDirection: 'row',
+        justifyContent: 'center',
+        padding: 16,
+        shadowColor: '#000',
+        shadowOffset: {
+            height: 2,
+            width: 0,
+        },
+        shadowOpacity: 0.25,
+            shadowRadius: 3.84,
+        },
+    buttonText: {
+        color: theme.colors.background,
+        fontSize: 16,
+        fontWeight: '600',
+        textAlign: 'center',
+    },
+}));

--- a/cli/src/templates/packages/unistyles/components/Container.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/Container.tsx.ejs
@@ -1,9 +1,17 @@
-import { SafeAreaView } from 'react-native';
-import { useStyles } from 'react-native-unistyles';
+import React from 'react';
+import { View } from 'react-native';
+import { StyleSheet } from 'react-native-unistyles';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
-  const { theme } = useStyles();
-
-  return <SafeAreaView style={theme.components.container}>{children}</SafeAreaView>;
+    return (
+        <View style={styles.container}>{children}</View>
+    );
 };
 
+const styles = StyleSheet.create((theme, rt) => ({
+    container: {
+        flex: 1,
+        paddingBottom: rt.insets.bottom,
+        backgroundColor: theme.colors.background,
+    },
+}));

--- a/cli/src/templates/packages/unistyles/components/EditScreenInfo.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/EditScreenInfo.tsx.ejs
@@ -1,61 +1,64 @@
 import { Text, View } from 'react-native';
-import { createStyleSheet, useStyles } from 'react-native-unistyles';
+import { StyleSheet } from 'react-native-unistyles';
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
-import { useTranslation } from 'react-i18next';
+    import { useTranslation } from 'react-i18next';
 <% } %>
 
 export const EditScreenInfo = ({ path }: { path: string }) => {
-  const { styles } = useStyles(stylesheet);
 <% if (props.internalizationPackage?.name === "i18next") { %>
-  const { t } = useTranslation();
-  const title = t('getStarted');
-  const description = t('changeCode')
+    const { t } = useTranslation();
+    const title = t('getStarted');
+    const description = t('changeCode')
 <% } else { %>
-  const title = "Open up the code for this screen:"
-  const description = "Change any of the text, save the file, and your app will automatically update."
+    const title = "Open up the code for this screen:"
+    const description = "Change any of the text, save the file, and your app will automatically update."
 <% } %>
-  return (
-    <View>
-      <View style={styles.getStartedContainer}>
-        <Text style={styles.getStartedText}>{title}</Text>
-        <View style={[styles.codeHighlightContainer, styles.homeScreenFilename]}>
-          <Text>{path}</Text>
+    return (
+        <View>
+            <View style={styles.getStartedContainer}>
+                <Text style={styles.getStartedText}>{title}</Text>
+                <View style={[styles.codeHighlightContainer, styles.homeScreenFilename]}>
+                    <Text style={styles.text}>{path}</Text>
+                </View>
+                <Text style={styles.getStartedText}>
+                    {description}
+                </Text>
+            </View>
         </View>
-        <Text style={styles.getStartedText}>
-          {description}
-        </Text>
-      </View>
-    </View>
-  );
+    );
 }
 
-const stylesheet = createStyleSheet({
-  codeHighlightContainer: {
-    borderRadius: 3,
-    paddingHorizontal: 4,
-  },
-  getStartedContainer: {
-    alignItems: 'center',
-    marginHorizontal: 50,
-  },
-  getStartedText: {
-    fontSize: 17,
-    lineHeight: 24,
-    textAlign: 'center',
-  },
-  helpContainer: {
-    alignItems: 'center',
-    marginHorizontal: 20,
-    marginTop: 15,
-  },
-  helpLink: {
-    paddingVertical: 15,
-  },
-  helpLinkText: {
-    textAlign: 'center',
-  },
-  homeScreenFilename: {
-    marginVertical: 7,
-  },
-});
+const styles = StyleSheet.create((theme) => ({
+    codeHighlightContainer: {
+        borderRadius: 3,
+        paddingHorizontal: 4,
+    },
+    getStartedContainer: {
+        alignItems: 'center',
+        marginHorizontal: 50,
+    },
+    text: {
+        color: theme.colors.typography,
+    },
+    getStartedText: {
+        fontSize: 17,
+        lineHeight: 24,
+        textAlign: 'center',
+        color: theme.colors.typography,
+    },
+    helpContainer: {
+        alignItems: 'center',
+        marginHorizontal: 20,
+        marginTop: 15,
+    },
+    helpLink: {
+        paddingVertical: 15,
+    },
+    helpLinkText: {
+        textAlign: 'center',
+    },
+    homeScreenFilename: {
+        marginVertical: 7,
+    },
+}));

--- a/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
@@ -31,7 +31,7 @@ const styles = StyleSheet.create(theme => ({
         height: 1,
         marginVertical: 30,
         width: '80%',
-        backgroundColor: theme.colors.typography,
+        backgroundColor: theme.colors.limedSpruce,
     },
     title: {
         fontSize: 20,

--- a/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
@@ -26,6 +26,7 @@ const styles = StyleSheet.create(theme => ({
         alignItems: 'center',
         justifyContent: 'center',
         padding: 24,
+        backgroundColor: theme.colors.background,
     },
     separator: {
         height: 1,

--- a/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
+++ b/cli/src/templates/packages/unistyles/components/ScreenContent.tsx.ejs
@@ -1,24 +1,41 @@
 import { Text, View } from 'react-native';
-import { useStyles } from 'react-native-unistyles';
+import { StyleSheet } from 'react-native-unistyles';
 
 import { EditScreenInfo } from './EditScreenInfo';
 
 type ScreenContentProps = {
-  title: string;
-  path: string;
-  children?: React.ReactNode;
+    title: string;
+    path: string;
+    children?: React.ReactNode;
 };
-
 
 export const ScreenContent = ({ title, path, children } : ScreenContentProps) => {
-  const { theme } = useStyles();
-
-  return (
-    <View style={theme.components.container}>
-      <Text style={theme.components.title}>{title}</Text>
-      <View style={theme.components.separator} />
-      <EditScreenInfo path={path} />
-      {children}
-    </View>
-  );
+    return (
+        <View style={styles.container}>
+            <Text style={styles.title}>{title}</Text>
+            <View style={styles.separator} />
+            <EditScreenInfo path={path} />
+            {children}
+        </View>
+    );
 };
+
+const styles = StyleSheet.create(theme => ({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+    },
+    separator: {
+        height: 1,
+        marginVertical: 30,
+        width: '80%',
+        backgroundColor: theme.colors.typography,
+    },
+    title: {
+        fontSize: 20,
+        fontWeight: 'bold',
+        color: theme.colors.typography,
+    },
+}));

--- a/cli/src/templates/packages/unistyles/theme.ts.ejs
+++ b/cli/src/templates/packages/unistyles/theme.ts.ejs
@@ -1,61 +1,34 @@
-const colors = {
-  white: '#ffffff',
-  azureRadiance: '#007AFF',
-  limedSpruce: '#38434D',
-  cornflowerBlue: '#6366F1',
-  astral: '#2E78B7'
+const sharedColors = {
+    azureRadiance: '#007AFF',
+    limedSpruce: '#38434D',
+    cornflowerBlue: '#6366F1',
+    astral: '#2E78B7'
 } as const;
 
 export const lightTheme = {
-  colors,
-  components: {
-    container: {
-			alignItems: 'center',
-			flex: 1,
-			justifyContent: 'center',
-      padding: 24,
-		},
-    separator: {
-      height: 1,
-      marginVertical: 30,
-      width: '80%',
-      backgroundColor: 'grey',
+    colors: {
+        ...sharedColors,
+        typography: '#000000',
+        background: '#ffffff',
     },
-      button: {
-        alignItems: 'center',
-        backgroundColor: colors.cornflowerBlue,
-        borderRadius: 24,
-        elevation: 5,
-        flexDirection: 'row',
-        justifyContent: 'center',
-        padding: 16,
-        shadowColor: '#000',
-        shadowOffset: {
-          height: 2,
-          width: 0,
-        },
-        shadowOpacity: 0.25,
-        shadowRadius: 3.84,
-      },
-      buttonText: {
-        color: colors.white,
-        fontSize: 16,
-        fontWeight: '600',
-        textAlign: 'center',
-      },
-      title: {
-        fontSize: 20,
-        fontWeight: 'bold',
-      },
-      subtitle: {
-        color: colors.limedSpruce,
-        fontSize: 36,
-      },
-  },
-  margins: {
-    sm: 2,
-    md: 4,
-    lg: 8,
-    xl: 12,
-  },
+    margins: {
+        sm: 2,
+        md: 4,
+        lg: 8,
+        xl: 12,
+    },
+} as const;
+
+export const darkTheme = {
+    colors: {
+        ...sharedColors,
+        typography: '#ffffff',
+        background: '#000000',
+    },
+    margins: {
+        sm: 2,
+        md: 4,
+        lg: 8,
+        xl: 12,
+    },
 } as const;

--- a/cli/src/templates/packages/unistyles/unistyles.ts.ejs
+++ b/cli/src/templates/packages/unistyles/unistyles.ts.ejs
@@ -5,13 +5,11 @@ import { lightTheme, darkTheme } from './theme';
 
 type AppBreakpoints = typeof breakpoints;
 
-// if you defined themes
 type AppThemes = {
     light: typeof lightTheme;
     dark: typeof darkTheme;
 };
 
-// override library types
 declare module 'react-native-unistyles' {
     export interface UnistylesBreakpoints extends AppBreakpoints {}
     export interface UnistylesThemes extends AppThemes {}

--- a/cli/src/templates/packages/unistyles/unistyles.ts.ejs
+++ b/cli/src/templates/packages/unistyles/unistyles.ts.ejs
@@ -1,27 +1,29 @@
-import { UnistylesRegistry } from 'react-native-unistyles';
+import { StyleSheet } from 'react-native-unistyles';
 
 import { breakpoints } from './breakpoints';
-import { lightTheme } from './theme';
+import { lightTheme, darkTheme } from './theme';
 
 type AppBreakpoints = typeof breakpoints;
 
 // if you defined themes
 type AppThemes = {
-  light: typeof lightTheme;
+    light: typeof lightTheme;
+    dark: typeof darkTheme;
 };
 
 // override library types
 declare module 'react-native-unistyles' {
-  export interface UnistylesBreakpoints extends AppBreakpoints {}
-  export interface UnistylesThemes extends AppThemes {}
-}
+    export interface UnistylesBreakpoints extends AppBreakpoints {}
+    export interface UnistylesThemes extends AppThemes {}
+};
 
-UnistylesRegistry.addBreakpoints(breakpoints)
-  .addThemes({
-    light: lightTheme,
-    // register other themes with unique names
-  })
-  .addConfig({
-    // you can pass here optional config described below
-    adaptiveThemes: true,
-  });
+StyleSheet.configure({
+    breakpoints,
+    themes: {
+        light: lightTheme,
+        dark: darkTheme
+    },
+    settings: {
+        adaptiveThemes: true
+    }
+});

--- a/cli/src/utilities/configureProjectFiles.ts
+++ b/cli/src/utilities/configureProjectFiles.ts
@@ -252,6 +252,7 @@ export function configureProjectFiles(
         expoRouterFiles.push('packages/nativewind/components/Button.tsx.ejs');
       } else if (stylingPackage?.name === 'unistyles') {
         expoRouterFiles.push('packages/unistyles/components/Button.tsx.ejs');
+        expoRouterFiles.push('packages/expo-router/index.js.ejs');
       } else if (stylingPackage?.name === 'tamagui') {
         expoRouterFiles.push('packages/tamagui/components/Button.tsx.ejs');
       } else if (stylingPackage?.name === 'stylesheet') {

--- a/cli/src/utilities/systemCommand.ts
+++ b/cli/src/utilities/systemCommand.ts
@@ -10,7 +10,8 @@ export async function runSystemCommand({
   stdio,
   toolbox,
   shell = true,
-  env
+  env,
+  failOnError = true
 }: {
   command: string;
   toolbox: Toolbox;
@@ -18,6 +19,7 @@ export async function runSystemCommand({
   errorMessage: string;
   shell?: boolean;
   env?: Record<string, string>;
+  failOnError?: boolean;
 }) {
   const {
     print: { error },
@@ -30,11 +32,13 @@ export async function runSystemCommand({
     env
   });
 
-  if (result.error || result.status !== 0) {
+  if (failOnError && (result.error || result.status !== 0)) {
     error(`${errorMessage}: ${JSON.stringify(result)}`);
 
     error(`failed to run command: ${command}`);
 
     return process.exit(1);
+  } else {
+    return result.stdout;
   }
 }


### PR DESCRIPTION
Expo Router:
- [x] - Stack
- [x] - Tabs
- [x] - Drawer + Tabs

React Navigation:
- [x] - Stack
- [x] - Tabs
- [x] - Drawer + Tabs

Other:
- [x] - None

@dannyhw @danstepanov PR is ready to be tested! I checked all UI templates mentioned above. 

It would be good to merge it in a few days after I release `beta.8`. It should land on Tue or Wed next week.