### PR TITLE
add missing react import

### DIFF
--- a/.changeset/cuddly-eagles-ring.md
+++ b/.changeset/cuddly-eagles-ring.md
@@ -1,0 +1,5 @@
+---
+'create-expo-stack': patch
+---
+
+add jsx config for TS

--- a/cli/src/templates/base/tsconfig.json.ejs
+++ b/cli/src/templates/base/tsconfig.json.ejs
@@ -1,7 +1,8 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
+    "strict": true,
+    "jsx": "react-jsx"
     <% if (props.flags.importAlias) { %>
       ,
     "baseUrl": ".",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

<!--- Describe your changes in detail -->
<!--- If your PR affects visual changes then please provide before and after images, gifs, or videos (below) -->
A bunch of files that utilize Fragments (`<>`) don't import React which causes a TS error. This change adds those imports.

## Related Issue

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue linked above, you can remove this section -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `bun test` but it failed, send help.

## Screenshots (if appropriate):
