### PR TITLE
 [cli] fix: switching Text from react-native to nativewindui component in NativewindUI CLI Template

### DIFF
--- a/cli/src/templates/packages/nativewindui/components/EditScreenInfo.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/EditScreenInfo.tsx.ejs
@@ -1,4 +1,6 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { Text } from '~/components/nativewindui/Text';
 
 <% if (props.internalizationPackage?.name === "i18next") { %>
 import { useTranslation } from 'react-i18next';
@@ -15,11 +17,15 @@ export default function EditScreenInfo({ path }: { path: string }) {
 <% } %>
   return (
     <View style={styles.getStartedContainer}>
-      <Text style={styles.getStartedText}>{title}</Text>
+      <Text variant="heading" className="text-center">
+        {title}
+      </Text>
       <View style={[styles.codeHighlightContainer, styles.homeScreenFilename]}>
         <Text>{path}</Text>
       </View>
-      <Text style={styles.getStartedText}>{description}</Text>
+      <Text variant="body" className="text-center">
+        {description}
+      </Text>
     </View>
   );
 }
@@ -32,11 +38,6 @@ const styles = StyleSheet.create({
   getStartedContainer: {
     alignItems: 'center',
     marginHorizontal: 50,
-  },
-  getStartedText: {
-    fontSize: 17,
-    lineHeight: 24,
-    textAlign: 'center',
   },
   helpContainer: {
     alignItems: 'center',

--- a/cli/src/templates/packages/nativewindui/components/ScreenContent.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/ScreenContent.tsx.ejs
@@ -1,4 +1,6 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+
+import { Text } from '~/components/nativewindui/Text';
 
 import EditScreenInfo from './EditScreenInfo';
 
@@ -11,7 +13,9 @@ type ScreenContentProps = {
 export const ScreenContent = ({ title, path, children }: ScreenContentProps) => {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{title}</Text>
+      <Text variant="title1" className="text-center">
+        {title}
+      </Text>
       <View style={styles.separator} />
       <EditScreenInfo path={path} />
       {children}
@@ -30,9 +34,5 @@ const styles = StyleSheet.create({
     height: 1,
     marginVertical: 30,
     width: '80%',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
## Description

When building a project with the NativewindUI option, specifically using the expo-router with tabs for navigation, the text within both the Modal and Tab 2 screens does not update its styling when the theme (light/dark mode) is toggled.

Updating the ScreenContent.tsx.ejs and EditScreenInfo.tsx.ejs template files to import from the nativewindui component

## Related Issue

[Issue-518](https://github.com/roninoss/create-expo-stack/issues/518)

## Motivation and Context

This is a small tweak thats been bugging me since my first use of create-expo-app last year, and now I know enough to fix it for everyone <3

## How Has This Been Tested?

Its a very small change that uses the same coding patterns as other components within the template 
"worked in my local before I pushed to prod at 5am" - words of some ex-employee of some company

## Screenshots (if appropriate):

Screenshots before my fix are posted in issue 518, these are post fix: 

![IMG_1565](https://github.com/user-attachments/assets/ddf44538-b3c5-4a29-a3d6-7b0f27339764)
![IMG_1564](https://github.com/user-attachments/assets/ec112ebd-120f-41b5-871a-c8630c705cb2)
