### PR TITLE
[cli] fix: Remove use of StyleSheet, non-tailwind styles, hardcoded color in in NativewindUI template components/pages

### DIFF
--- a/cli/src/templates/packages/nativewindui/components/BackButton.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/BackButton.tsx.ejs
@@ -1,23 +1,20 @@
 import { Feather } from '@expo/vector-icons';
-import { Text, View, StyleSheet } from 'react-native';
+import { View } from 'react-native';
+
+import { Text } from '~/components/nativewindui/Text';
 
 export const BackButton = ({ onPress }: { onPress: () => void }) => {
   return (
-    <View style={styles.backButton}>
+    <View className={styles.backButton}>
       <Feather name="chevron-left" size={16} color="#007AFF" />
-      <Text style={styles.backButtonText} onPress={onPress}>
+      <Text variant="body" className={styles.backButtonText} onPress={onPress}>
         Back
       </Text>
     </View>
   );
 };
-const styles = StyleSheet.create({
-  backButton: {
-    flexDirection: 'row',
-    paddingLeft: 20,
-  },
-  backButtonText: {
-    color: '#007AFF',
-    marginLeft: 4,
-  },
-});
+
+const styles = {
+  backButton: 'flex-row pl-5',
+  backButtonText: 'text-primary ml-1',
+};

--- a/cli/src/templates/packages/nativewindui/components/Button.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/Button.tsx.ejs
@@ -1,5 +1,7 @@
 import { forwardRef } from 'react';
-import { StyleSheet, Text, TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+import { TouchableOpacity, TouchableOpacityProps, View } from 'react-native';
+
+import { Text } from '~/components/nativewindui/Text';
 
 type ButtonProps = {
   title?: string;
@@ -7,35 +9,20 @@ type ButtonProps = {
 
 export const Button = forwardRef<View, ButtonProps>(({ title, ...touchableProps }, ref) => {
   return (
-    <TouchableOpacity ref={ref} {...touchableProps} style={[styles.button, touchableProps.style]}>
-      <Text style={styles.buttonText}>{title}</Text>
+    <TouchableOpacity
+      ref={ref}
+      {...touchableProps}
+      className={`${styles.button} ${touchableProps.className || ''}`}>
+      <Text variant="callout" className={styles.buttonText}>
+        {title}
+      </Text>
     </TouchableOpacity>
   );
 });
 
 Button.displayName = 'Button';
 
-const styles = StyleSheet.create({
-  button: {
-    alignItems: 'center',
-    backgroundColor: '#6366F1',
-    borderRadius: 24,
-    elevation: 5,
-    flexDirection: 'row',
-    justifyContent: 'center',
-    padding: 16,
-    shadowColor: '#000',
-    shadowOffset: {
-      height: 2,
-      width: 0,
-    },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-  },
-  buttonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-    textAlign: 'center',
-  },
-});
+const styles = {
+  button: 'items-center bg-primary rounded-3xl p-4 flex-row justify-center shadow-lg',
+  buttonText: 'text-primary-foreground font-semibold text-center',
+};

--- a/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
@@ -1,13 +1,9 @@
-import { StyleSheet, SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
-  return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;
+  return <SafeAreaView className={styles.container}>{children}</SafeAreaView>;
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
-});
-
+const styles = {
+  container: 'flex-1 p-6',
+};

--- a/cli/src/templates/packages/nativewindui/components/EditScreenInfo.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/EditScreenInfo.tsx.ejs
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { Text } from '~/components/nativewindui/Text';
 
@@ -16,11 +16,11 @@ export default function EditScreenInfo({ path }: { path: string }) {
   const description = "Change any of the text, save the file, and your app will automatically update."
 <% } %>
   return (
-    <View style={styles.getStartedContainer}>
+    <View className={styles.getStartedContainer}>
       <Text variant="heading" className="text-center">
         {title}
       </Text>
-      <View style={[styles.codeHighlightContainer, styles.homeScreenFilename]}>
+      <View className={`${styles.codeHighlightContainer} ${styles.homeScreenFilename}`}>
         <Text>{path}</Text>
       </View>
       <Text variant="body" className="text-center">
@@ -30,27 +30,11 @@ export default function EditScreenInfo({ path }: { path: string }) {
   );
 }
 
-const styles = StyleSheet.create({
-  codeHighlightContainer: {
-    borderRadius: 3,
-    paddingHorizontal: 4,
-  },
-  getStartedContainer: {
-    alignItems: 'center',
-    marginHorizontal: 50,
-  },
-  helpContainer: {
-    alignItems: 'center',
-    marginHorizontal: 20,
-    marginTop: 15,
-  },
-  helpLink: {
-    paddingVertical: 15,
-  },
-  helpLinkText: {
-    textAlign: 'center',
-  },
-  homeScreenFilename: {
-    marginVertical: 7,
-  },
-});
+const styles = {
+  codeHighlightContainer: 'rounded-[3px] px-1',
+  getStartedContainer: 'items-center mx-[50px]',
+  helpContainer: 'items-center mx-5 mt-[15px]',
+  helpLink: 'py-[15px]',
+  helpLinkText: 'text-center',
+  homeScreenFilename: 'my-[7px]'
+};

--- a/cli/src/templates/packages/nativewindui/components/HeaderButton.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/HeaderButton.tsx.ejs
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { Pressable, StyleSheet } from 'react-native';
+import { Pressable } from 'react-native';
 
 export const HeaderButton = forwardRef<typeof Pressable, { onPress?: () => void; }>(({ onPress }, ref) => {
   return (
@@ -10,12 +10,8 @@ export const HeaderButton = forwardRef<typeof Pressable, { onPress?: () => void;
           name="info-circle"
           size={25}
           color="gray"
-          style={[
-            styles.headerRight,
-            {
-              opacity: pressed ? 0.5 : 1,
-            },
-          ]}
+          className={styles.headerRight}
+          style={{ opacity: pressed ? 0.5 : 1 }}
         />
       )}
     </Pressable>
@@ -24,8 +20,6 @@ export const HeaderButton = forwardRef<typeof Pressable, { onPress?: () => void;
 
 HeaderButton.displayName = 'HeaderButton';
 
-export const styles = StyleSheet.create({
-  headerRight: {
-    marginRight: 15,
-  },
-});
+const styles = {
+  headerRight: 'mr-[15px]',
+};

--- a/cli/src/templates/packages/nativewindui/components/ScreenContent.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/ScreenContent.tsx.ejs
@@ -1,4 +1,4 @@
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { Text } from '~/components/nativewindui/Text';
 
@@ -12,27 +12,16 @@ type ScreenContentProps = {
 
 export const ScreenContent = ({ title, path, children }: ScreenContentProps) => {
   return (
-    <View style={styles.container}>
-      <Text variant="title1" className="text-center">
-        {title}
-      </Text>
-      <View style={styles.separator} />
+    <View className={styles.container}>
+      <Text variant="title1">{title}</Text>
+      <View className={styles.separator} />
       <EditScreenInfo path={path} />
       {children}
     </View>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center',
-  },
-  separator: {
-    backgroundColor: '#d1d5db',
-    height: 1,
-    marginVertical: 30,
-    width: '80%',
-  },
-});
+const styles = {
+  container: 'flex-1 items-center justify-center',
+  separator: 'h-px w-4/5 bg-border my-[30px]',
+};

--- a/cli/src/templates/packages/nativewindui/components/TabBarIcon.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/TabBarIcon.tsx.ejs
@@ -1,15 +1,12 @@
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { StyleSheet } from 'react-native';
 
 export const TabBarIcon = (props: {
   name: React.ComponentProps<typeof FontAwesome>['name'];
   color: string;
 }) => {
-  return <FontAwesome size={28} style={styles.tabBarIcon} {...props} />;
+  return <FontAwesome size={28} className={styles.tabBarIcon} {...props} />;
 };
 
-export const styles = StyleSheet.create({
-  tabBarIcon: {
-    marginBottom: -3,
-  },
-});
+const styles = {
+  tabBarIcon: '-mb-[3px]',
+};

--- a/cli/src/templates/packages/nativewindui/tabs/app/(tabs)/_layout.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/(tabs)/_layout.tsx.ejs
@@ -1,14 +1,16 @@
 import { Link, Tabs } from "expo-router";
 import { HeaderButton } from '../../components/HeaderButton';
 import { TabBarIcon } from '../../components/TabBarIcon';
+import { useColorScheme } from '~/lib/useColorScheme';
 
 
 
 export default function TabLayout() {
+  const { colors } = useColorScheme();
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: 'black',
+        tabBarActiveTintColor: colors.foreground,
       }}>
       <Tabs.Screen
         name='index'

--- a/cli/src/templates/packages/nativewindui/tabs/app/(tabs)/two.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/(tabs)/two.tsx.ejs
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { StyleSheet, View } from 'react-native';
+import { View } from 'react-native';
 
 import { ScreenContent } from '~/components/ScreenContent';
 
@@ -7,16 +7,13 @@ export default function Home() {
   return (
     <>
       <Stack.Screen options={{ title: 'Tab Two' }} />
-      <View style={styles.container}>
+      <View className={styles.container}>
         <ScreenContent path="app/(tabs)/two.tsx" title="Tab Two" />
       </View>
     </>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 24,
-  },
-});
+const styles = {
+  container: 'flex-1 p-6',
+};

--- a/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
@@ -1,6 +1,9 @@
 import { Link, Stack } from 'expo-router';
-<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
+<% if (props.stylingPackage?.name === "nativewind") {%>
   import { Text, View } from 'react-native';
+<% } else if (props.stylingPackage?.name === "nativewindui") {%>
+  import { View } from 'react-native';
+  import { Text } from '~/components/nativewindui/Text';
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
   import { createStyleSheet, useStyles } from 'react-native-unistyles'
   import { Text, View } from 'react-native';
@@ -23,13 +26,23 @@ export default function NotFoundScreen() {
 <% } %>
 
   return (
-      <% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) {%>
+      <% if (props.stylingPackage?.name === "nativewind") {%>
         <>
-          <Stack.Screen options={{ title: "Oops!" }} />
+          <Stack.Screen options={{ title: 'Oops!' }} />
           <View className={styles.container}>
             <Text className={styles.title}>{"This screen doesn't exist."}</Text>
             <Link href="/" className={styles.link}>
               <Text className={styles.linkText}>Go to home screen!</Text>
+            </Link>
+          </View>
+        </>
+      <% } else if (props.stylingPackage?.name === "nativewindui") {%>
+        <>
+          <Stack.Screen options={{ title: 'Oops!' }} />
+          <View className={styles.container}>
+            <Text variant="title2" className={styles.title}>{"This screen doesn't exist."}</Text>
+            <Link href="/" className={styles.link}>
+              <Text variant="body" className={styles.linkText}>Go to home screen!</Text>
             </Link>
           </View>
         </>
@@ -71,13 +84,13 @@ export default function NotFoundScreen() {
   );
 }
 
-<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
+<% if (props.stylingPackage?.name === "nativewind" || props.stylingPackage?.name === "nativewindui") { %>
   const styles = {
-		container: `items-center flex-1 justify-center p-5`,
-    title: `text-xl font-bold`,
-    link: `mt-4 pt-4`,
-    linkText: `text-base text-[#2e78b7]`,
-	};
+    container: 'items-center flex-1 justify-center p-5',
+    title: 'font-bold text-center',
+    link: 'mt-4 pt-4',
+    linkText: 'text-primary',
+  };
 <% } else if (props.stylingPackage?.name === "unistyles") { %>
   const stylesheet = createStyleSheet((theme) => ({
     container: {

--- a/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/tabs/app/+not-found.tsx.ejs
@@ -84,7 +84,7 @@ export default function NotFoundScreen() {
   );
 }
 
-<% if (props.stylingPackage?.name === "nativewind" || props.stylingPackage?.name === "nativewindui") { %>
+<% if (["nativewind", "nativewindui"].includes(props.stylingPackage?.name)) { %>
   const styles = {
     container: 'items-center flex-1 justify-center p-5',
     title: 'font-bold text-center',


### PR DESCRIPTION

## Description

Refactoring the NativewindUI template app components to use tailwindcss styles instead of stylesheet
Removing hardcoded black color from tab bar icons/text in favor of using theme
Changed Text to use nativewindui instead of react-native Text component in +not-found, button, back-button
Removed hardcoded color from +not-found, changed backticks to single quotes for consistency with other pages

Dark Theme Tab Before:

![IMG_1578](https://github.com/user-attachments/assets/4f28e8d2-f7e5-45b3-98ca-258567cc34d8)

Dark Theme Tab After:

![IMG_1577](https://github.com/user-attachments/assets/6f52adfe-5572-4d97-8d5a-bf3fe5b88297)

No other noticeable visual changes

## Related Issue

https://github.com/roninoss/create-expo-stack/issues/521

## Motivation and Context

Each template should showcase examples of its intended style patterns

## How Has This Been Tested?

In my local. No architectural changes, just visual or matching recent changes

## Screenshots (if appropriate):

See above
