### PR TITLE
[cli] fix: Change imports for deprecated SafeAreView from react-native

### DIFF
--- a/cli/src/templates/base/components/Container.tsx.ejs
+++ b/cli/src/templates/base/components/Container.tsx.ejs
@@ -1,4 +1,7 @@
-import { StyleSheet, SafeAreaView } from 'react-native';
+
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet } from 'react-native';
+
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;

--- a/cli/src/templates/packages/nativewind/components/Container.tsx.ejs
+++ b/cli/src/templates/packages/nativewind/components/Container.tsx.ejs
@@ -1,4 +1,4 @@
-import { SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView className={styles.container}>{children}</SafeAreaView>;

--- a/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
+++ b/cli/src/templates/packages/nativewindui/components/Container.tsx.ejs
@@ -1,4 +1,5 @@
-import { StyleSheet, SafeAreaView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet } from 'react-native';
 
 export const Container = ({ children }: { children: React.ReactNode }) => {
   return <SafeAreaView style={styles.container}>{children}</SafeAreaView>;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Your title should include which part of the project your PR applies to (ex: [cli], [docs], [www]) -->

## Description

Changed the import for `SafeAreaView` from `'react-native'` to `'react-native-safe-area-context'` , because of deprecation

## Related Issue

Swap SafeAreaView for SafeAreaContext #539

## Motivation and Context

Because of deprecation warning 
