### PR TITLE
fix: correct EAS install guidance

### DIFF
--- a/.changeset/eas-install-guidance.md
+++ b/.changeset/eas-install-guidance.md
@@ -1,0 +1,6 @@
+---
+'create-expo-stack': patch
+'rn-new': patch
+---
+
+Correct EAS completion output so install steps are shown only for no-install flows.

--- a/cli/src/utilities/printOutput.ts
+++ b/cli/src/utilities/printOutput.ts
@@ -263,7 +263,7 @@ export async function printOutput(
     info(`To build for development:`);
     info(``);
     highlight(`${step}. cd ${projectDir}`);
-    if (!flags.noInstall) highlight(`${++step}. ${packageManager} install`);
+    if (flags.noInstall) highlight(`${++step}. ${packageManager} install`);
     highlight(`${++step}. eas build --profile=development`);
     highlight(`${++step}. ${runCommand} start`);
 
@@ -274,7 +274,7 @@ export async function printOutput(
     info(`To create a build to share with others:`);
     info(``);
     highlight(`${step}. cd ${projectDir}`);
-    if (!flags.noInstall) highlight(`${++step}. ${packageManager} install`);
+    if (flags.noInstall) highlight(`${++step}. ${packageManager} install`);
     highlight(`${++step}. eas build --profile=preview`);
 
     info(``);


### PR DESCRIPTION
﻿## Summary
- fix EAS completion output so install steps are shown only when the project was generated with `--no-install`
- add a patch changeset for `create-expo-stack` and `rn-new`

## Context
This was split out of #616 because it is independent of the Expo SDK 57 upgrade. In the normal EAS flow, dependencies have already been installed before the final instructions print, so the extra install step is redundant.

## Verification
- `bun run build:cli`

I also attempted `bun run test` from `cli/`, but the main-branch NativeWindUI generation path hung in `nwui-cli` and the command timed out after 5 minutes before producing test output. The CLI build/typecheck completed successfully.
